### PR TITLE
Update submodule names to match repo path

### DIFF
--- a/docgen/go.mod
+++ b/docgen/go.mod
@@ -1,4 +1,4 @@
-module github.com/onflow/cadence/tools/docgen
+module github.com/onflow/cadence-tools/docgen
 
 go 1.18
 

--- a/languageserver/go.mod
+++ b/languageserver/go.mod
@@ -1,4 +1,4 @@
-module github.com/onflow/cadence/languageserver
+module github.com/onflow/cadence-tools/languageserver
 
 go 1.18
 

--- a/lint/go.mod
+++ b/lint/go.mod
@@ -1,4 +1,4 @@
-module github.com/onflow/cadence-lint
+module github.com/onflow/cadence-tools/lint
 
 go 1.19
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,4 +1,4 @@
-module github.com/onflow/cadence-test
+module github.com/onflow/cadence-tools/test
 
 go 1.18
 


### PR DESCRIPTION
## Description

`go get` command needs the module path to match the repo-path.
e.g:
```
module declares its path as: github.com/onflow/cadence-test
	        but was required as: github.com/onflow/cadence-tools/test
```

All module paths in `go.mod` files was updated to `github.com/onflow/cadence-tools/xxx` 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
