### PR TITLE
Fix value decoding during argument passing and return value decoding

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -3,7 +3,7 @@ module github.com/onflow/cadence-tools/test
 go 1.18
 
 require (
-	github.com/onflow/cadence v0.28.0
+	github.com/onflow/cadence v0.28.1-0.20221017183505-4cb5613cb0fc
 	github.com/onflow/flow-emulator v0.38.0
 	github.com/onflow/flow-go v0.26.14-test-synchronization.0.20221011174222-54840e416e81
 	github.com/onflow/flow-go-sdk v0.29.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -550,8 +550,8 @@ github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1
 github.com/onflow/atree v0.4.0 h1:+TbNisavAkukAKhgQ4plWnvR9o5+SkwPIsi3jaeAqKs=
 github.com/onflow/atree v0.4.0/go.mod h1:7Qe1xaW0YewvouLXrugzMFUYXNoRQ8MT/UsVAWx1Ndo=
 github.com/onflow/cadence v0.15.0/go.mod h1:KMzDF6cIv6nb5PJW9aITaqazbmJX8MMeibFcpPP385M=
-github.com/onflow/cadence v0.28.0 h1:18A1V9xqGewibEhuzqBNEoNvqG6OwVqHg7gKu3UliaM=
-github.com/onflow/cadence v0.28.0/go.mod h1:h+SbY8RNl6Q6sT6l/2cvpUZUJNCbzJya+3Bkwe/0YwY=
+github.com/onflow/cadence v0.28.1-0.20221017183505-4cb5613cb0fc h1:oJuTiScD24l04te2OTWexSoznL7MLobfKakTeGuwkys=
+github.com/onflow/cadence v0.28.1-0.20221017183505-4cb5613cb0fc/go.mod h1:h+SbY8RNl6Q6sT6l/2cvpUZUJNCbzJya+3Bkwe/0YwY=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220720151516-797b149ceaaa h1:hcEp3INfkLh9jFODC9PHPQeisAd9rterujabee9il8w=
 github.com/onflow/flow-core-contracts/lib/go/contracts v0.11.2-0.20220720151516-797b149ceaaa/go.mod h1:T6yhM+kWrFxiP6F3hh8lh9DcocHfmv48P4ITnjLhKSk=
 github.com/onflow/flow-core-contracts/lib/go/templates v0.11.2-0.20220720151516-797b149ceaaa h1:0brc9iDezo2Gc7yH3p7+La1iFe4WRDg6HYT6llyP8+E=

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -185,8 +185,7 @@ func (r *TestRunner) runTestSetup(inter *interpreter.Interpreter) error {
 }
 
 func hasSetup(inter *interpreter.Interpreter) bool {
-	_, ok := inter.Globals.Get(setupFunctionName)
-	return ok
+	return inter.Globals.Contains(setupFunctionName)
 }
 
 func (r *TestRunner) runTestTearDown(inter *interpreter.Interpreter) error {
@@ -198,8 +197,7 @@ func (r *TestRunner) runTestTearDown(inter *interpreter.Interpreter) error {
 }
 
 func hasTearDown(inter *interpreter.Interpreter) bool {
-	_, ok := inter.Globals.Get(tearDownFunctionName)
-	return ok
+	return inter.Globals.Contains(tearDownFunctionName)
 }
 
 func (r *TestRunner) invokeTestFunction(inter *interpreter.Interpreter, funcName string) (err error) {


### PR DESCRIPTION
Closes #33

## Description

Use the same interpreter instance which is used to run the test-script also to decode values, rather than instantiating a new interpreter instance. 

Depends on: https://github.com/onflow/cadence/pull/2074

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
