### PR TITLE
Include issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,27 @@
+---
+name: Requesting a Feature or Improvement
+about: "For feature requests. Please search for existing issues first. Also see CONTRIBUTING."
+title: ''
+labels: Feedback, Feature
+assignees: ''
+
+---
+
+## Instructions
+
+Please fill out the template below to the best of your ability and include a label indicating which tool/service you were working with when you encountered the problem.
+
+### Issue To Be Solved
+(Replace This Text: Please present a concise description of the problem to be addressed by this feature request. Please be clear what parts of the problem are considered to be in-scope and out-of-scope.)
+
+### (Optional): Suggest A Solution
+(Replace This Text: A concise description of your preferred solution. Things to address include:
+* Details of the technical implementation
+* Tradeoffs made in design decisions
+* Caveats and considerations for the future
+
+If there are multiple solutions, please present each one separately. Save comparisons for the very end.)
+  
+### (Optional): Context
+
+<what are you currently working on that this is blocking?>

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,28 @@
+---
+name: Reporting a Problem/Bug
+about: Reporting a Problem/Bug
+title: ''
+labels: bug, Feedback
+assignees: ''
+
+---
+
+## Instructions
+
+Please fill out the template below to the best of your ability and include a label indicating which tool/service you were working with when you encountered the problem.
+
+### Problem
+
+<what is the problem you've encountered?> 
+
+### Steps to Reproduce 
+
+<share any logs/screenshots or steps to replicate>
+
+### Acceptance Criteria
+
+<if any>
+  
+### Context
+
+<what are you currently working on that this is blocking?>

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,27 @@
+---
+name: Requesting a Feature or Improvement
+about: "For feature requests. Please search for existing issues first. Also see CONTRIBUTING."
+title: ''
+labels: Feedback, Feature
+assignees: ''
+
+---
+
+## Instructions
+
+Please fill out the template below to the best of your ability and include a label indicating which tool/service you were working with when you encountered the problem.
+
+### Issue To Be Solved
+(Replace This Text: Please present a concise description of the problem to be addressed by this feature request. Please be clear what parts of the problem are considered to be in-scope and out-of-scope.)
+
+### (Optional): Suggest A Solution
+(Replace This Text: A concise description of your preferred solution. Things to address include:
+* Details of the technical implementation
+* Tradeoffs made in design decisions
+* Caveats and considerations for the future
+
+If there are multiple solutions, please present each one separately. Save comparisons for the very end.)
+  
+### (Optional): Context
+
+<what are you currently working on that this is blocking?>


### PR DESCRIPTION
Closes #?? (didn't create an issue for it)

## Description

This repo was missing the issue templates. The duplicated template directly under the .github folder was needed for github properly auto filling issues when you create a new one. 
______

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
