### PR TITLE
[LS] Using local emulator

### DIFF
--- a/languageserver/integration/flow.go
+++ b/languageserver/integration/flow.go
@@ -103,10 +103,14 @@ func (f *flowkitClient) Initialize(configPath string, numberOfAccounts int) erro
 		return err
 	}
 
-	hostedEmulator := gateway.NewEmulatorGateway(serviceAccount)
+	var emulator gateway.Gateway
+	// try connecting to already running local emulator
+	emulator, err = gateway.NewGrpcGateway(config.DefaultEmulatorNetwork().Host)
+	if err != nil { // fallback to hosted emulator if error
+		emulator = gateway.NewEmulatorGateway(serviceAccount)
+	}
 
-	f.services = services.NewServices(hostedEmulator, state, logger)
-
+	f.services = services.NewServices(emulator, state, logger)
 	if numberOfAccounts > len(names) || numberOfAccounts <= 0 {
 		return fmt.Errorf(fmt.Sprintf("only possible to create between 1 and %d accounts", len(names)))
 	}

--- a/languageserver/integration/flow.go
+++ b/languageserver/integration/flow.go
@@ -106,7 +106,7 @@ func (f *flowkitClient) Initialize(configPath string, numberOfAccounts int) erro
 	var emulator gateway.Gateway
 	// try connecting to already running local emulator
 	emulator, err = gateway.NewGrpcGateway(config.DefaultEmulatorNetwork().Host)
-	if err != nil { // fallback to hosted emulator if error
+	if err != nil || emulator.Ping() != nil { // fallback to hosted emulator if error
 		emulator = gateway.NewEmulatorGateway(serviceAccount)
 	}
 


### PR DESCRIPTION
Closes: #49 

This PR is implementing usage of a local emulator if one is already running, otherwise, it hosts it's own. The reason for this is to allow developer share same emulator between tools. 
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
