### PR TITLE
[LS] Strip extra slash on windows paths

### DIFF
--- a/languageserver/integration/commands.go
+++ b/languageserver/integration/commands.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/onflow/flow-cli/pkg/flowkit"
 	"github.com/onflow/flow-go-sdk"
@@ -75,9 +76,9 @@ func (c *commands) getAll() []server.Command {
 // source document in VS Code.
 //
 // There should be exactly 3 arguments:
-//   * the DocumentURI of the file to submit
-//   * the arguments, encoded as JSON-CDC
-//   * the signer names as list
+//   - the DocumentURI of the file to submit
+//   - the arguments, encoded as JSON-CDC
+//   - the signer names as list
 func (c *commands) sendTransaction(args ...json.RawMessage) (any, error) {
 	err := server.CheckCommandArgumentCount(args, 3)
 	if err != nil {
@@ -132,8 +133,8 @@ func (c *commands) sendTransaction(args ...json.RawMessage) (any, error) {
 // executeScript handles executing a script defined in the source document.
 //
 // There should be exactly 2 arguments:
-//   * the DocumentURI of the file to submit
-//   * the arguments, encoded as JSON-CDC
+//   - the DocumentURI of the file to submit
+//   - the arguments, encoded as JSON-CDC
 func (c *commands) executeScript(args ...json.RawMessage) (any, error) {
 	err := server.CheckCommandArgumentCount(args, 2)
 	if err != nil {
@@ -168,7 +169,7 @@ func (c *commands) executeScript(args ...json.RawMessage) (any, error) {
 // when submitting transactions.
 //
 // There should be 1 argument:
-//	 * name of the new active account
+//   - name of the new active account
 func (c *commands) switchActiveAccount(args ...json.RawMessage) (any, error) {
 	err := server.CheckCommandArgumentCount(args, 1)
 	if err != nil {
@@ -208,9 +209,9 @@ func (c *commands) createAccount(_ ...json.RawMessage) (any, error) {
 // file.
 //
 // There should be exactly 3 arguments:
-//   * the DocumentURI of the file to submit
-//   * the name of the contract
-//   * the signer names as list
+//   - the DocumentURI of the file to submit
+//   - the name of the contract
+//   - the signer names as list
 func (c *commands) deployContract(args ...json.RawMessage) (any, error) {
 	err := server.CheckCommandArgumentCount(args, 3)
 	if err != nil {
@@ -262,6 +263,12 @@ func parseLocation(arg []byte) (*url.URL, error) {
 	location, err := url.Parse(uri)
 	if err != nil {
 		return nil, fmt.Errorf("invalid path argument: %s", uri)
+	}
+
+	// workaround for Windows files being sent with prefixed '/' which is /c:/test/foo
+	// we remove the first / for Windows files, so they are valid
+	if strings.Contains(location.Path, ":") {
+		location.Path = location.Path[1:]
 	}
 
 	return location, nil


### PR DESCRIPTION
Closes #55

## Description
This handles windows paths with prefix `/` otherwise the location is not valid. 

Related to https://github.com/microsoft/vscode/issues/170618

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
