### PR TITLE
[LS] Bugfix clean Windows paths in resolvers

### DIFF
--- a/languageserver/integration/commands.go
+++ b/languageserver/integration/commands.go
@@ -21,11 +21,9 @@ package integration
 import (
 	"encoding/json"
 	"fmt"
-	"net/url"
-	"strings"
-
 	"github.com/onflow/flow-cli/pkg/flowkit"
 	"github.com/onflow/flow-go-sdk"
+	"net/url"
 
 	"github.com/onflow/cadence-tools/languageserver/server"
 )
@@ -275,11 +273,7 @@ func parseLocation(arg []byte) (*url.URL, error) {
 		return nil, fmt.Errorf("invalid path argument: %s", uri)
 	}
 
-	// workaround for Windows files being sent with prefixed '/' which is /c:/test/foo
-	// we remove the first / for Windows files, so they are valid
-	if strings.Contains(location.Path, ":") {
-		location.Path = location.Path[1:]
-	}
+	location.Path = cleanWindowsPath(location.Path)
 
 	return location, nil
 }

--- a/languageserver/integration/flow.go
+++ b/languageserver/integration/flow.go
@@ -90,8 +90,8 @@ func newFlowkitClient(loader flowkit.ReaderWriter) *flowkitClient {
 }
 
 func (f *flowkitClient) Initialize(configPath string, numberOfAccounts int) error {
-	f.configPath = configPath
-	state, err := flowkit.Load([]string{configPath}, f.loader)
+	f.configPath = cleanWindowsPath(configPath)
+	state, err := flowkit.Load([]string{f.configPath}, f.loader)
 	if err != nil {
 		return err
 	}

--- a/languageserver/integration/flow.go
+++ b/languageserver/integration/flow.go
@@ -90,7 +90,7 @@ func newFlowkitClient(loader flowkit.ReaderWriter) *flowkitClient {
 }
 
 func (f *flowkitClient) Initialize(configPath string, numberOfAccounts int) error {
-	f.configPath = cleanWindowsPath(configPath)
+	f.configPath = configPath
 	state, err := flowkit.Load([]string{f.configPath}, f.loader)
 	if err != nil {
 		return err

--- a/languageserver/integration/integration.go
+++ b/languageserver/integration/integration.go
@@ -93,6 +93,7 @@ func (i *FlowIntegration) initialize(initializationOptions any) error {
 	if !ok || configPath == "" {
 		return errors.New("initialization options: invalid config path")
 	}
+	configPath = cleanWindowsPath(configPath)
 
 	numberOfAccountsString, ok := optsMap["numberOfAccounts"].(string)
 	if !ok || numberOfAccountsString == "" {

--- a/languageserver/integration/mock_flow_test.go
+++ b/languageserver/integration/mock_flow_test.go
@@ -161,6 +161,20 @@ func (_m *mockFlowClient) Initialize(configPath string, numberOfAccounts int) er
 	return r0
 }
 
+// Reload provides a mock function with given fields:
+func (_m *mockFlowClient) Reload() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SendTransaction provides a mock function with given fields: authorizers, location, args
 func (_m *mockFlowClient) SendTransaction(authorizers []flow.Address, location *url.URL, args []cadence.Value) (*flow.Transaction, *flow.TransactionResult, error) {
 	ret := _m.Called(authorizers, location, args)

--- a/languageserver/integration/resolvers.go
+++ b/languageserver/integration/resolvers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/flow-cli/pkg/flowkit"
 	"github.com/onflow/flow-go-sdk"
+	"strings"
 )
 
 type resolvers struct {
@@ -30,7 +31,7 @@ type resolvers struct {
 }
 
 func (r *resolvers) fileImport(location common.StringLocation) (string, error) {
-	filename := string(location)
+	filename := cleanWindowsPath(location.String())
 
 	data, err := r.loader.ReadFile(filename)
 	if err != nil {
@@ -63,4 +64,14 @@ func (r *resolvers) addressContractNames(address common.Address) ([]string, erro
 	}
 
 	return names, nil
+}
+
+// workaround for Windows files being sent with prefixed '/' which is /c:/test/foo
+// we remove the first / for Windows files, so they are valid, also replace encoded column sign.
+func cleanWindowsPath(path string) string {
+	path = strings.ReplaceAll(path, "%3A", ":")
+	if strings.Contains(path, ":") {
+		path = path[1:]
+	}
+	return path
 }


### PR DESCRIPTION
Closes https://github.com/onflow/vscode-cadence/issues/224

## Description
Clean windows paths in import resolvers since they are passed with a prefix and URL encoded format (e.g. `/c%3A/foo/bar.cdc`)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
