### PR TITLE
[LS] Flow client flag consistent with CLI

### DIFF
--- a/languageserver/cmd/languageserver/main.go
+++ b/languageserver/cmd/languageserver/main.go
@@ -22,14 +22,13 @@
 package main
 
 import (
-	"flag"
-
 	"github.com/onflow/cadence-tools/languageserver"
+	"github.com/spf13/pflag"
 )
 
-var enableFlowClientFlag = flag.Bool("enableFlowClient", true, "enable Flow client functionality")
+var enableFlowClientFlag = pflag.Bool("enable-flow-client", true, "enable Flow client functionality")
 
 func main() {
-	flag.Parse()
+	pflag.Parse()
 	languageserver.RunWithStdio(*enableFlowClientFlag)
 }

--- a/languageserver/go.mod
+++ b/languageserver/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/onflow/flow-go-sdk v0.31.0
 	github.com/sourcegraph/jsonrpc2 v0.1.0
 	github.com/spf13/afero v1.9.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/exp v0.0.0-20221126150942-6ab00d035af9
 )
@@ -137,7 +138,6 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/cobra v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.12.0 // indirect
 	github.com/steakknife/bloomfilter v0.0.0-20180922174646-6819c0d2a570 // indirect
 	github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3 // indirect

--- a/languageserver/run.sh
+++ b/languageserver/run.sh
@@ -5,7 +5,7 @@ SCRIPTPATH=$(dirname "$0")
 if [ "$1" = "cadence" ] && [ "$2" = "language-server" ] ; then
 	(cd "$SCRIPTPATH" && \
 		go build -gcflags="all=-N -l" ./cmd/languageserver && \
-		dlv --log-dest 2 --continue --listen=:2345 --headless=true --api-version=2 --accept-multiclient exec ./languageserver "$@");
+		dlv --log-dest 2 --continue --listen=:2345 --headless=true --api-version=2 --accept-multiclient exec ./languageserver -- "$@");
 else
 	flow "$@"
 fi

--- a/languageserver/test/index.test.ts
+++ b/languageserver/test/index.test.ts
@@ -32,7 +32,7 @@ class ConsoleTracer implements Tracer {
 
 async function withConnection(f: (connection: ProtocolConnection) => Promise<void>, enableFlowClient = false, debug = false): Promise<void> {
 
-  let opts = [`-enableFlowClient=${enableFlowClient}`]
+  let opts = [`--enable-flow-client=${enableFlowClient}`]
   const child = spawn(
     path.resolve(__dirname, './languageserver'),
     opts


### PR DESCRIPTION
Make the flow client flag consistent with CLI and also change the run.sh script so it actually passes the flags to the ls.
______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
