### PR TITLE
[LS] Don't force showing messages

### DIFF
--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -1785,12 +1785,6 @@ func (s *Server) InlayHint(
 // Shutdown tells the server to stop accepting any new requests. This can only
 // be followed by a call to Exit, which exits the process.
 func (*Server) Shutdown(conn protocol.Conn) error {
-
-	conn.ShowMessage(&protocol.ShowMessageParams{
-		Type:    protocol.Warning,
-		Message: "Cadence language server is shutting down",
-	})
-
 	return nil
 }
 

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -1785,6 +1785,12 @@ func (s *Server) InlayHint(
 // Shutdown tells the server to stop accepting any new requests. This can only
 // be followed by a call to Exit, which exits the process.
 func (*Server) Shutdown(conn protocol.Conn) error {
+
+	conn.LogMessage(&protocol.LogMessageParams{
+		Type:    protocol.Warning,
+		Message: "Cadence language server is shutting down",
+	})
+
 	return nil
 }
 


### PR DESCRIPTION
LS shouldn't decide on what is important to the client. Log the shutdown message instead.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
