### PR TITLE
Lint: Add support for plugins

### DIFF
--- a/lint/analyzer.go
+++ b/lint/analyzer.go
@@ -26,17 +26,17 @@ import (
 )
 
 const (
-	ReplacementCategory     string = "replacement-hint"
-	RemovalCategory         string = "removal-hint"
-	UpdateCategory          string = "update recommended"
-	UnnecessaryCastCategory string = "unnecessary-cast-hint"
+	ReplacementCategory     = "replacement-hint"
+	RemovalCategory         = "removal-hint"
+	UpdateCategory          = "update recommended"
+	UnnecessaryCastCategory = "unnecessary-cast-hint"
 )
 
 var Analyzers = map[string]*analysis.Analyzer{}
 
 var analyzerNamePattern = regexp.MustCompile(`\w+`)
 
-func registerAnalyzer(name string, analyzer *analysis.Analyzer) {
+func RegisterAnalyzer(name string, analyzer *analysis.Analyzer) {
 	if _, ok := Analyzers[name]; ok {
 		panic(fmt.Errorf("analyzer already exists: %s", name))
 	}

--- a/lint/deprecated_key_functions_analyzer.go
+++ b/lint/deprecated_key_functions_analyzer.go
@@ -102,7 +102,7 @@ var DeprecatedKeyFunctionsAnalyzer = (func() *analysis.Analyzer {
 })()
 
 func init() {
-	registerAnalyzer(
+	RegisterAnalyzer(
 		"deprecated-key-functions",
 		DeprecatedKeyFunctionsAnalyzer,
 	)

--- a/lint/number_function_argument_analyzer.go
+++ b/lint/number_function_argument_analyzer.go
@@ -223,7 +223,7 @@ var NumberFunctionArgumentAnalyzer = (func() *analysis.Analyzer {
 })()
 
 func init() {
-	registerAnalyzer(
+	RegisterAnalyzer(
 		"number-function-arguments",
 		NumberFunctionArgumentAnalyzer,
 	)

--- a/lint/redundant_cast_analyzer.go
+++ b/lint/redundant_cast_analyzer.go
@@ -323,7 +323,7 @@ var RedundantCastAnalyzer = (func() *analysis.Analyzer {
 })()
 
 func init() {
-	registerAnalyzer(
+	RegisterAnalyzer(
 		"redundant-cast",
 		RedundantCastAnalyzer,
 	)

--- a/lint/reference_operator_analyzer.go
+++ b/lint/reference_operator_analyzer.go
@@ -86,7 +86,7 @@ var ReferenceOperatorAnalyzer = (func() *analysis.Analyzer {
 })()
 
 func init() {
-	registerAnalyzer(
+	RegisterAnalyzer(
 		"reference-operator",
 		ReferenceOperatorAnalyzer,
 	)

--- a/lint/unnecessary_force_analyzer.go
+++ b/lint/unnecessary_force_analyzer.go
@@ -76,7 +76,7 @@ var UnnecessaryForceAnalyzer = (func() *analysis.Analyzer {
 })()
 
 func init() {
-	registerAnalyzer(
+	RegisterAnalyzer(
 		"unnecessary-force",
 		UnnecessaryForceAnalyzer,
 	)


### PR DESCRIPTION
## Description

Similar to golangci-lint, allow linters/analyzers to be loaded at run-time using Go's plugin system.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
