### PR TITLE
Update parameters of Execute function call to flowkit scripts service

### DIFF
--- a/languageserver/integration/flow.go
+++ b/languageserver/integration/flow.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onflow/flow-cli/pkg/flowkit/gateway"
 	"github.com/onflow/flow-cli/pkg/flowkit/output"
 	"github.com/onflow/flow-cli/pkg/flowkit/services"
+	"github.com/onflow/flow-cli/pkg/flowkit/util"
 	"github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
 )
@@ -201,6 +202,7 @@ func (f *flowkitClient) ExecuteScript(
 	return f.services.Scripts.Execute(
 		flowkit.NewScript(code, args, codeFilename),
 		config.DefaultEmulatorNetwork().Name,
+		&util.ScriptQuery{},
 	)
 }
 


### PR DESCRIPTION
Closes https://github.com/onflow/flow-cli/issues/893

## Description

**NOTE**: This is an update needed as a part of a breaking change in flowkit API.

Developers are now able to specify an optional block id/height, to execute a script against it. Example usage:

For a specific `blockID`:
```bash
~/Dev/forks/flow-cli/cmd/flow/flow-x86_64-linux- scripts execute get_moment_nft_supply.cdc --block-id=a6d53bf47d581eaac2de46182b441ca2b37ca13d88130d9edfccf9ae68055522 --host dps-001.mainnet22.nodes.onflow.org:9000

Result: 1085553
```

For a specific `block height`:
```bash
~/Dev/forks/flow-cli/cmd/flow/flow-x86_64-linux- scripts execute get_moment_nft_supply.cdc --block-height=47711580 --host dps-001.mainnet22.nodes.onflow.org:9000

Result: 1285613
```

For the latest block:
```bash
~/Dev/forks/flow-cli/cmd/flow/flow-x86_64-linux- scripts execute get_moment_nft_supply.cdc --network=mainnet                                                                  

Result: 1338863
```
______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-cli/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
