### PR TITLE
Add analyzer to detect and report parameters that have an `AuthAccount` type

### DIFF
--- a/lint/auth_account_parameter_analyzer.go
+++ b/lint/auth_account_parameter_analyzer.go
@@ -45,14 +45,15 @@ var AuthAccountParameterAnalyzer = (func() *analysis.Analyzer {
 			inspector.Preorder(
 				elementFilter,
 				func(element ast.Element) {
-					functionDeclaration, isFD := element.(*ast.FunctionDeclaration)
-					specialFunctionDeclaration, isSFD := element.(*ast.SpecialFunctionDeclaration)
 					var parameterList *ast.ParameterList
-					if isSFD && specialFunctionDeclaration.DeclarationKind() == common.DeclarationKindInitializer {
-						parameterList = specialFunctionDeclaration.FunctionDeclaration.ParameterList
-					} else if isFD {
-						parameterList = functionDeclaration.ParameterList
-					} else {
+					switch declaration := element.(type) {
+					case *ast.FunctionDeclaration:
+						parameterList = declaration.ParameterList
+					case *ast.SpecialFunctionDeclaration:
+						if declaration.DeclarationKind() == common.DeclarationKindInitializer {
+							parameterList = declaration.FunctionDeclaration.ParameterList
+						}
+					default:
 						return
 					}
 

--- a/lint/auth_account_parameter_analyzer.go
+++ b/lint/auth_account_parameter_analyzer.go
@@ -1,0 +1,86 @@
+/*
+ * Cadence-lint - The Cadence linter
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lint
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/tools/analysis"
+)
+
+var AuthAccountParameterAnalyzer = (func() *analysis.Analyzer {
+
+	elementFilter := []ast.Element{
+		(*ast.FunctionDeclaration)(nil),
+		(*ast.SpecialFunctionDeclaration)(nil),
+	}
+
+	return &analysis.Analyzer{
+		Description: "Detects functions with AuthAccount type parameters",
+		Requires: []*analysis.Analyzer{
+			analysis.InspectorAnalyzer,
+		},
+		Run: func(pass *analysis.Pass) interface{} {
+			inspector := pass.ResultOf[analysis.InspectorAnalyzer].(*ast.Inspector)
+
+			location := pass.Program.Location
+			report := pass.Report
+
+			inspector.Preorder(
+				elementFilter,
+				func(element ast.Element) {
+					functionDeclaration, isFD := element.(*ast.FunctionDeclaration)
+					specialFunctionDeclaration, isSFD := element.(*ast.SpecialFunctionDeclaration)
+					var parameterList *ast.ParameterList
+					if isSFD && specialFunctionDeclaration.DeclarationKind() == common.DeclarationKindInitializer {
+						parameterList = specialFunctionDeclaration.FunctionDeclaration.ParameterList
+					} else if isFD {
+						parameterList = functionDeclaration.ParameterList
+					} else {
+						return
+					}
+
+					for _, parameter := range parameterList.Parameters {
+						nominalType, ok := parameter.TypeAnnotation.Type.(*ast.NominalType)
+						if ok && nominalType.Identifier.Identifier == "AuthAccount" {
+							report(
+								analysis.Diagnostic{
+									Location:         location,
+									Range:            ast.NewRangeFromPositioned(nil, element),
+									Category:         UpdateCategory,
+									Message:          "It is an anti-pattern to pass AuthAccount to functions.",
+									SecondaryMessage: "Consider using Capabilities instead.",
+								},
+							)
+						}
+					}
+				},
+			)
+
+			return nil
+		},
+	}
+})()
+
+func init() {
+	RegisterAnalyzer(
+		"auth-account-parameter",
+		AuthAccountParameterAnalyzer,
+	)
+}

--- a/lint/auth_account_parameter_analyzer_test.go
+++ b/lint/auth_account_parameter_analyzer_test.go
@@ -1,0 +1,152 @@
+/*
+ * Cadence-lint - The Cadence linter
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lint_test
+
+import (
+	"testing"
+
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/tools/analysis"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence-tools/lint"
+)
+
+func TestAuthAccountParameterAnalyzerInContractFunction(t *testing.T) {
+
+	t.Parallel()
+
+	diagnostics := testAnalyzers(t,
+		`
+		    pub contract BalanceChecker {
+		        pub fun getBalance(account: AuthAccount): UFix64 {
+		            return account.balance
+		        }
+		    }
+		`,
+		lint.AuthAccountParameterAnalyzer,
+	)
+
+	require.Equal(
+		t,
+		[]analysis.Diagnostic{
+			{
+				Range: ast.Range{
+					StartPos: ast.Position{Offset: 47, Line: 3, Column: 10},
+					EndPos:   ast.Position{Offset: 145, Line: 5, Column: 10},
+				},
+				Location:         testLocation,
+				Category:         lint.UpdateCategory,
+				Message:          "It is an anti-pattern to pass AuthAccount to functions.",
+				SecondaryMessage: "Consider using Capabilities instead.",
+			},
+		},
+		diagnostics,
+	)
+}
+
+func TestAuthAccountParameterAnalyzerInContractInitFunction(t *testing.T) {
+
+	t.Parallel()
+
+	diagnostics := testAnalyzers(t,
+		`
+		    pub contract BalanceChecker {
+		        pub let balance: UFix64
+		        init(account: AuthAccount) {
+		            self.balance = account.balance
+		        }
+		    }
+		`,
+		lint.AuthAccountParameterAnalyzer,
+	)
+
+	require.Equal(
+		t,
+		[]analysis.Diagnostic{
+			{
+				Range: ast.Range{
+					StartPos: ast.Position{Offset: 81, Line: 4, Column: 10},
+					EndPos:   ast.Position{Offset: 165, Line: 6, Column: 10},
+				},
+				Location:         testLocation,
+				Category:         lint.UpdateCategory,
+				Message:          "It is an anti-pattern to pass AuthAccount to functions.",
+				SecondaryMessage: "Consider using Capabilities instead.",
+			},
+		},
+		diagnostics,
+	)
+}
+
+func TestAuthAccountParameterAnalyzerInStructInitFunction(t *testing.T) {
+
+	t.Parallel()
+
+	diagnostics := testAnalyzers(t,
+		`
+		    pub struct Balance {
+		        pub let balance: UFix64
+		        init(account: AuthAccount) {
+		            self.balance = account.balance
+		        }
+		    }
+		`,
+		lint.AuthAccountParameterAnalyzer,
+	)
+
+	require.Equal(
+		t,
+		[]analysis.Diagnostic{
+			{
+				Range: ast.Range{
+					StartPos: ast.Position{Offset: 72, Line: 4, Column: 10},
+					EndPos:   ast.Position{Offset: 156, Line: 6, Column: 10},
+				},
+				Location:         testLocation,
+				Category:         lint.UpdateCategory,
+				Message:          "It is an anti-pattern to pass AuthAccount to functions.",
+				SecondaryMessage: "Consider using Capabilities instead.",
+			},
+		},
+		diagnostics,
+	)
+}
+
+func TestAuthAccountParameterAnalyzerWithPublicAccount(t *testing.T) {
+
+	t.Parallel()
+
+	diagnostics := testAnalyzers(t,
+		`
+		    pub contract BalanceChecker {
+		        pub fun getBalance(account: PublicAccount): UFix64 {
+		            return account.balance
+		        }
+		    }
+		`,
+		lint.AuthAccountParameterAnalyzer,
+	)
+
+	require.Equal(
+		t,
+		[]analysis.Diagnostic(nil),
+		diagnostics,
+	)
+}


### PR DESCRIPTION
Closes https://github.com/onflow/cadence-tools/issues/4

## Description

It is an anti-pattern to pass `AuthAccount`s to functions.
We introduce a new analyzer to detect and report parameters that have an `AuthAccount` type.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
