### PR TITLE
Fix links to the packages in the README

### DIFF
--- a/languageserver/README.md
+++ b/languageserver/README.md
@@ -57,7 +57,7 @@ instead of the Flow CLI binary, and allowing this server to be debugged, e.g. us
     ```
 4. In Visual Studio Code, go to Settings
 5. Search for `Cadence: Flow Command`, and enter the full path to the `run.sh` script
-   found in this directory (for example: `/Users/dapper/Dev/cadence/languageserver/run.sh`).
+   found in this directory (for example: `/Users/dapper/Dev/cadence-tools/languageserver/run.sh`).
 
 This allows the language server to be re-built each time it is restarted:
 - Kill Delve: `killall dlv` (Delve ignores SIGINT in headless mode)

--- a/languageserver/README.md
+++ b/languageserver/README.md
@@ -18,7 +18,7 @@ and also in the [Flow Playground](https://play.onflow.org/)
 
 ### Main functionality
 
-The main functionality of the language server, such as providing reporting diagnostics (e.g. errors), auto completion, etc. is implemented in the [`server` package](https://github.com/onflow/cadence/tree/master/languageserver/server).
+The main functionality of the language server, such as providing reporting diagnostics (e.g. errors), auto completion, etc. is implemented in the [`server` package](https://github.com/onflow/cadence-tools/tree/master/languageserver/server).
 
 ### Integration with the Flow network
 
@@ -29,8 +29,8 @@ This code can be found in the [`integration` package](https://github.com/onflow/
 
 ### Language Server Protocol Types
 
-The Go code for the LSP types can be found in the [`protocol` package](https://github.com/onflow/cadence/tree/master/languageserver/protocol).
-The code is generated from the specification's TypeScript declarations using [scripts](https://github.com/onflow/cadence/tree/master/languageserver/scripts).
+The Go code for the LSP types can be found in the [`protocol` package](https://github.com/onflow/cadence-tools/tree/master/languageserver/protocol).
+The code is generated from the specification's TypeScript declarations using [scripts](https://github.com/onflow/cadence-tools/tree/master/languageserver/scripts).
 
 ### Building for WebAssembly
 
@@ -44,7 +44,7 @@ make wasm
 ### Tests
 
 The integration tests for the Cadence Language Server are written in TypeScript
-and can be found in the [`test` directory](https://github.com/onflow/cadence/tree/master/languageserver/test).
+and can be found in the [`test` directory](https://github.com/onflow/cadence-tools/tree/master/languageserver/test).
 
 ### Development and Debugging
 


### PR DESCRIPTION
## Description
Fixes a few links to point to the correct directory path in the README.

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
