### PR TITLE
Display Cadence logs during testing

### DIFF
--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -21,7 +21,10 @@ package test
 import (
 	"encoding/hex"
 	"fmt"
+	"os"
 	"strings"
+
+	"github.com/rs/zerolog"
 
 	sdk "github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
@@ -392,6 +395,11 @@ func newBlockchain(opts ...emulator.Option) *emulator.Blockchain {
 		append(
 			[]emulator.Option{
 				emulator.WithStorageLimitEnabled(false),
+				emulator.WithServerLogger(
+					zerolog.New(
+						zerolog.ConsoleWriter{Out: os.Stdout},
+					).With().Timestamp().Logger(),
+				),
 			},
 			opts...,
 		)...,

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -20,6 +20,7 @@ package test
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/rs/zerolog"
@@ -438,9 +439,18 @@ func newScriptEnvironment() environment.Environment {
 	vm := fvm.NewVirtualMachine()
 	ctx := fvm.NewContext(fvm.WithLogger(zerolog.Nop()))
 	snapshotTree := testutil.RootBootstrappedLedger(vm, ctx)
+	environmentParams := environment.DefaultEnvironmentParams()
+	logger := zerolog.New(
+		zerolog.ConsoleWriter{Out: os.Stdout},
+	).With().Timestamp().Logger()
+	environmentParams.ProgramLoggerParams = environment.ProgramLoggerParams{
+		Logger:                logger,
+		CadenceLoggingEnabled: true,
+		MetricsReporter:       environment.NoopMetricsReporter{},
+	}
 
 	return environment.NewScriptEnvironmentFromStorageSnapshot(
-		environment.DefaultEnvironmentParams(),
+		environmentParams,
 		snapshotTree,
 	)
 }


### PR DESCRIPTION
Closes https://github.com/onflow/cadence-tools/issues/103

## Description

Displays Cadence logs from unit/integration tests and test files, to the console.

![Screenshot from 2023-04-24 15-51-39](https://user-images.githubusercontent.com/1778965/234180557-aa394a2e-9813-4b20-ada2-b0254f6ff886.png)

**Note**: This is currently the default behavior, without a flag to enable/disable it.

**Note 2**: I tried to make the logs have the same look & feel, because some come from the Emulator's `Blockchain` ([CadenceHook](https://github.com/onflow/flow-emulator/blob/master/blockchain.go#L535)), however that ends up in double printing the rest of the logs, e.g:

![Screenshot from 2023-04-25 08-20-07](https://user-images.githubusercontent.com/1778965/234181574-9c2578fb-db5b-481f-ba5b-5a57e305eedf.png)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
