### PR TITLE
Exclude the omnipresent locations from code coverage

### DIFF
--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -277,9 +277,9 @@ func (e *EmulatorBackend) signTransaction(
 	for i := len(signerAccounts) - 1; i >= 0; i-- {
 		signerAccount := signerAccounts[i]
 
-		publicKey := string(signerAccount.PublicKey.PublicKey)
+		publicKey := signerAccount.PublicKey.PublicKey
 		accountKeys := e.accountKeys[signerAccount.Address]
-		keyInfo := accountKeys[publicKey]
+		keyInfo := accountKeys[string(publicKey)]
 
 		err := tx.SignPayload(sdk.Address(signerAccount.Address), 0, keyInfo.signer)
 		if err != nil {

--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -29,6 +29,7 @@ import (
 	sdk "github.com/onflow/flow-go-sdk"
 	"github.com/onflow/flow-go-sdk/crypto"
 	sdkTest "github.com/onflow/flow-go-sdk/test"
+	"github.com/onflow/flow-go/model/flow"
 
 	"github.com/onflow/flow-go/fvm"
 	fvmCrypto "github.com/onflow/flow-go/fvm/crypto"
@@ -74,6 +75,28 @@ type keyInfo struct {
 	signer     crypto.Signer
 }
 
+var systemContracts = func() []common.AddressLocation {
+	chain := flow.Emulator.Chain()
+	contracts := map[string]string{
+		"FlowServiceAccount": chain.ServiceAddress().HexWithPrefix(),
+		"FlowToken":          fvm.FlowTokenAddress(chain).HexWithPrefix(),
+		"FungibleToken":      fvm.FungibleTokenAddress(chain).HexWithPrefix(),
+		"FlowFees":           environment.FlowFeesAddress(chain).HexWithPrefix(),
+		"FlowStorageFees":    chain.ServiceAddress().HexWithPrefix(),
+	}
+
+	locations := make([]common.AddressLocation, 0)
+	for name, address := range contracts {
+		addr, _ := common.HexToAddress(address)
+		locations = append(locations, common.AddressLocation{
+			Address: addr,
+			Name:    name,
+		})
+	}
+
+	return locations
+}()
+
 func NewEmulatorBackend(
 	fileResolver FileResolver,
 	stdlibHandler stdlib.StandardLibraryHandler,
@@ -85,20 +108,7 @@ func NewEmulatorBackend(
 			emulator.WithCoverageReportingEnabled(true),
 		)
 		blockchain.SetCoverageReport(coverageReport)
-		chain := blockchain.GetChain()
-		contracts := map[string]string{
-			"FlowServiceAccount": chain.ServiceAddress().HexWithPrefix(),
-			"FlowToken":          fvm.FlowTokenAddress(chain).HexWithPrefix(),
-			"FungibleToken":      fvm.FungibleTokenAddress(chain).HexWithPrefix(),
-			"FlowFees":           environment.FlowFeesAddress(chain).HexWithPrefix(),
-			"FlowStorageFees":    chain.ServiceAddress().HexWithPrefix(),
-		}
-		for name, address := range contracts {
-			addr, _ := common.HexToAddress(address)
-			location := common.AddressLocation{
-				Address: addr,
-				Name:    name,
-			}
+		for _, location := range systemContracts {
 			coverageReport.ExcludeLocation(location)
 		}
 	} else {

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -572,7 +572,6 @@ func TestUsingEnv(t *testing.T) {
 
 		assert.True(t, resolverInvoked)
 	})
-
 }
 
 func TestCreateAccount(t *testing.T) {


### PR DESCRIPTION
Work towards: https://github.com/onflow/developer-grants/issues/132

## Description

Certain smart contracts, which are essential for the functioning of the Flow blockchain, are not needed in the context of coverage reporting. We exclude them, in order to avoid skewing the coverage report metrics.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
