### PR TITLE
Fix inlay hints: add type annotation for resource types

### DIFF
--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -1764,13 +1764,18 @@ func (s *Server) InlayHint(
 			continue // todo this should never occur
 		}
 
+		typeAnnotation := sema.TypeAnnotation{
+			Type:       targetType,
+			IsResource: targetType.IsResourceType(),
+		}
+
 		identifierEndPosition := variableDeclaration.Identifier.EndPosition(nil)
 		inlayHintPosition := conversion.ASTToProtocolPosition(identifierEndPosition.Shifted(nil, 1))
 		inlayHint := protocol.InlayHint{
 			Position: &inlayHintPosition,
 			Label: []protocol.InlayHintLabelPart{
 				{
-					Value: fmt.Sprintf(": %s", targetType.QualifiedString()),
+					Value: fmt.Sprintf(": %s", typeAnnotation.QualifiedString()),
 				},
 			},
 			Kind: protocol.Type,


### PR DESCRIPTION
## Description

When providing an inlay hint for a resource-kinded type, also provide the type annotation (`@`).

Noticed this during the Office Hours :-) 

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
