### PR TITLE
Fix unnamed import symbols

### DIFF
--- a/languageserver/conversion/conversion.go
+++ b/languageserver/conversion/conversion.go
@@ -120,16 +120,7 @@ func DeclarationToDocumentSymbol(declaration ast.Declaration) protocol.DocumentS
 			identifier.EndPosition(nil),
 		)
 	} else {
-		switch declarationKind {
-		case common.DeclarationKindTransaction:
-			name = "transaction"
-		case common.DeclarationKindInitializer:
-			name = "init"
-		case common.DeclarationKindDestructor:
-			name = "destroy"
-		case common.DeclarationKindImport:
-			name = "import"
-		}
+		name = declarationKind.Keywords()
 
 		declarationStartPos := ASTToProtocolPosition(declaration.StartPosition())
 		selectionRange = protocol.Range{

--- a/languageserver/conversion/conversion.go
+++ b/languageserver/conversion/conversion.go
@@ -127,6 +127,8 @@ func DeclarationToDocumentSymbol(declaration ast.Declaration) protocol.DocumentS
 			name = "init"
 		case common.DeclarationKindDestructor:
 			name = "destroy"
+		case common.DeclarationKindImport:
+			name = "import"
 		}
 
 		declarationStartPos := ASTToProtocolPosition(declaration.StartPosition())

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -1709,7 +1709,10 @@ func (s *Server) DocumentSymbol(
 
 	for _, declaration := range checker.Program.Declarations() {
 		symbol := conversion.DeclarationToDocumentSymbol(declaration)
-		symbols = append(symbols, &symbol)
+		// symbols with empty names will cause errors in the client
+		if strings.TrimSpace(symbol.Name) != "" {
+			symbols = append(symbols, &symbol)
+		}
 	}
 
 	return


### PR DESCRIPTION
Closes #125 

## Description

This PR solves import symbols having no name in LSP responses and causing errors in the client/vscode extension.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
