### PR TITLE
Add `EmulatorBackend.Reset` method and `beforeEach` / `afterEach` hooks

### DIFF
--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -493,3 +493,13 @@ func (e *EmulatorBackend) replaceImports(code string) string {
 func (e *EmulatorBackend) StandardLibraryHandler() stdlib.StandardLibraryHandler {
 	return e.stdlibHandler
 }
+
+func (e *EmulatorBackend) Reset() {
+	err := e.blockchain.ReloadBlockchain()
+	if err != nil {
+		panic(err)
+	}
+
+	// Reset the transaction offset.
+	e.blockOffset = 0
+}


### PR DESCRIPTION
Work towards: https://github.com/onflow/developer-grants/issues/148

## Description

The general idea here, is to have better control at resetting the state of the blockchain, and some flexible hooks to run before/after each test case. For example:

```cadence
import Test

pub let blockchain = Test.newEmulatorBlockchain()

pub fun beforeEach() {
    // Reset the state of the blockchain
    blockchain.reset()
}

// or the afterEach() can be used to reset the state
pub fun afterEach() {
    blockchain.reset()
}
```

This feature was first discussed about in https://github.com/orgs/onflow/discussions/1330
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
