### PR TITLE
Fix AuthAccount analyzer

### DIFF
--- a/lint/auth_account_parameter_analyzer.go
+++ b/lint/auth_account_parameter_analyzer.go
@@ -53,7 +53,9 @@ var AuthAccountParameterAnalyzer = (func() *analysis.Analyzer {
 						if declaration.DeclarationKind() == common.DeclarationKindInitializer {
 							parameterList = declaration.FunctionDeclaration.ParameterList
 						}
-					default:
+					}
+
+					if parameterList == nil {
 						return
 					}
 

--- a/lint/auth_account_parameter_analyzer_test.go
+++ b/lint/auth_account_parameter_analyzer_test.go
@@ -150,3 +150,23 @@ func TestAuthAccountParameterAnalyzerWithPublicAccount(t *testing.T) {
 		diagnostics,
 	)
 }
+
+func TestAuthAccountParameterAnalyzerWithTransaction(t *testing.T) {
+
+	t.Parallel()
+
+	diagnostics := testAnalyzers(t,
+		`
+		    transaction {
+		        prepare(account: AuthAccount) {}
+		    }
+		`,
+		lint.AuthAccountParameterAnalyzer,
+	)
+
+	require.Equal(
+		t,
+		[]analysis.Diagnostic(nil),
+		diagnostics,
+	)
+}


### PR DESCRIPTION
## Description

Fix a nil-dereference when analyzing function declarations that should be ignored.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
