### PR TITLE
Add support for retrieving `stdlib` events

### DIFF
--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -556,7 +556,7 @@ func (e *EmulatorBackend) StandardLibraryHandler() stdlib.StandardLibraryHandler
 }
 
 func (e *EmulatorBackend) Reset() {
-	err := e.blockchain.ReloadBlockchain()
+	err := e.blockchain.RollbackToBlockHeight(0)
 	if err != nil {
 		panic(err)
 	}

--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -123,6 +123,7 @@ func NewEmulatorBackend(
 			logCollectionHook,
 			emulator.WithCoverageReport(coverageReport),
 		)
+		coverageReport.Reset()
 	} else {
 		blockchain = newBlockchain(logCollectionHook)
 	}

--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -594,9 +594,6 @@ func (e *EmulatorBackend) Events(
 			panic(err)
 		}
 		for _, event := range sdkEvents {
-			if strings.Contains(event.Type, "flow.") {
-				continue
-			}
 			value, err := runtime.ImportValue(
 				inter,
 				interpreter.EmptyLocationRange,

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -3193,6 +3193,12 @@ func TestCoverageReportForIntegrationTests(t *testing.T) {
 	}
 
 	coverageReport := runtime.NewCoverageReport()
+	coverageReport.WithLocationFilter(func(location common.Location) bool {
+		_, addressLoc := location.(common.AddressLocation)
+		_, stringLoc := location.(common.StringLocation)
+		// We only allow inspection of AddressLocation or StringLocation
+		return addressLoc || stringLoc
+	})
 	runner := NewTestRunner().
 		WithFileResolver(fileResolver).
 		WithCoverageReport(coverageReport)
@@ -3258,9 +3264,10 @@ func TestCoverageReportForIntegrationTests(t *testing.T) {
 		},
 		coverageReport.ExcludedLocationIDs(),
 	)
+	assert.Equal(t, 1, coverageReport.TotalLocations())
 	assert.Equal(
 		t,
-		"Coverage: 96.4% of statements",
+		"Coverage: 100.0% of statements",
 		coverageReport.String(),
 	)
 }

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -3786,8 +3786,10 @@ func TestGetEventsFromIntegrationTests(t *testing.T) {
 	        Test.assert(events.length == 1)
 
 	        let evts = blockchain.events()
-	        log(evts[9])
-	        Test.assert(evts.length == 10)
+	        Test.assert(evts.length == 19)
+
+	        let blockchain2 = Test.newEmulatorBlockchain()
+	        Test.assert(blockchain2.events().length == 19)
 	    }
 	`
 

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -61,6 +61,8 @@ const afterEachFunctionName = "afterEach"
 
 var testScriptLocation = common.NewScriptLocation(nil, []byte("test"))
 
+var quotedLog = regexp.MustCompile("\"(.*)\"")
+
 type Results []Result
 
 type Result struct {
@@ -92,8 +94,7 @@ func (h *LogCollectionHook) Run(e *zerolog.Event, level zerolog.Level, msg strin
 			"",
 			1,
 		)
-		re := regexp.MustCompile("\"(.*)\"")
-		match := re.FindStringSubmatch(logMsg)
+		match := quotedLog.FindStringSubmatch(logMsg)
 		// Only logs with strings are quoted, eg:
 		// DBG LOG: "setup successful"
 		// We strip the quotes, to keep only the raw value.

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -86,15 +86,23 @@ func NewLogCollectionHook() *LogCollectionHook {
 
 func (h *LogCollectionHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
 	if level != zerolog.NoLevel {
-		msg = strings.Replace(
+		logMsg := strings.Replace(
 			msg,
 			"LOG:",
 			"",
 			1,
 		)
 		re := regexp.MustCompile("\"(.*)\"")
-		match := re.FindStringSubmatch(msg)
-		h.Logs = append(h.Logs, match[1])
+		match := re.FindStringSubmatch(logMsg)
+		// Only logs with strings are quoted, eg:
+		// DBG LOG: "setup successful"
+		// We strip the quotes, to keep only the raw value.
+		// Other logs may not contain quotes, eg:
+		// DBG LOG: flow.AccountCreated(address: 0x01cf0e2f2f715450)
+		if len(match) > 0 {
+			logMsg = match[1]
+		}
+		h.Logs = append(h.Logs, logMsg)
 	}
 }
 

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -662,7 +662,17 @@ func (r *TestRunner) parseAndCheckImport(
 		importedLocation common.Location,
 		importRange ast.Range,
 	) (sema.Import, error) {
-		return nil, fmt.Errorf("nested imports are not supported")
+		switch importedLocation {
+		case stdlib.TestContractLocation:
+			testChecker := stdlib.GetTestContractType().Checker
+			elaboration := testChecker.Elaboration
+			return sema.ElaborationImport{
+				Elaboration: elaboration,
+			}, nil
+
+		default:
+			return nil, fmt.Errorf("nested imports are not supported")
+		}
 	}
 
 	env.CheckerConfig.ContractValueHandler = contractValueHandler


### PR DESCRIPTION
## Description

- Fix regex issue, when parsing non-string log messages
- Add support for `stdlib` events that have type `flow.*`
- Allow importing the `Test` contract in helper files
-  Update `EmulatorBackend.Reset()` function to use `Blockchain.RollbackToBlockHeight()` instead of `Blockchain.ReloadBlockchain()`
- Improve `CoverageReport` metrics to include only contracts

Such events, can even be printed to the console:

```bash
1:04PM DBG LOG: flow.AccountCreated(address: 0x01cf0e2f2f715450)
```

![Screenshot from 2023-06-07 13-04-49](https://github.com/onflow/cadence-tools/assets/1778965/266e2cbb-a7b4-4aa8-b3db-f279799703b8)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
