### PR TITLE
[lint] Update to Cadence v0.39.4

### DIFF
--- a/lint/go.mod
+++ b/lint/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v0.39.2
-	github.com/onflow/flow-go-sdk v0.41.1
+	github.com/onflow/cadence v0.39.4
+	github.com/onflow/flow-go-sdk v0.41.2
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15
 	google.golang.org/grpc v1.53.0

--- a/lint/go.sum
+++ b/lint/go.sum
@@ -39,10 +39,10 @@ github.com/logrusorgru/aurora/v4 v4.0.0 h1:sRjfPpun/63iADiSvGGjgA1cAYegEWMPCJdUp
 github.com/logrusorgru/aurora/v4 v4.0.0/go.mod h1:lP0iIa2nrnT/qoFXcOZSrZQpJ1o6n2CUf/hyHi2Q4ZQ=
 github.com/onflow/atree v0.6.0 h1:j7nQ2r8npznx4NX39zPpBYHmdy45f4xwoi+dm37Jk7c=
 github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVFi0tc=
-github.com/onflow/cadence v0.39.2 h1:GfLsLx1O93xAKdItdiy3bWb9OfQXK1z9KFAzZ05smns=
-github.com/onflow/cadence v0.39.2/go.mod h1:OIJLyVBPa339DCBQXBfGaorT4tBjQh9gSKe+ZAIyyh0=
-github.com/onflow/flow-go-sdk v0.41.1 h1:VXT5TvA+WmpedOcbkXu+65wq+N+j5Yu3VvxCDqLoc3U=
-github.com/onflow/flow-go-sdk v0.41.1/go.mod h1:tiGY/eGgk3/aeeJ5DBu2AeaJfoqI9o1S614dLrIl4Js=
+github.com/onflow/cadence v0.39.4 h1:Rg2WUtrgXWADHlN2n0NKo+0sAdijx67oiTNdrG0vJOM=
+github.com/onflow/cadence v0.39.4/go.mod h1:OIJLyVBPa339DCBQXBfGaorT4tBjQh9gSKe+ZAIyyh0=
+github.com/onflow/flow-go-sdk v0.41.2 h1:O/yjdS0V+NHgg98QeVWQt2aDJ+m3znGgBOPy/PfrhXo=
+github.com/onflow/flow-go-sdk v0.41.2/go.mod h1:SJ2oAvz3FHCyNfDw7XojmIxsduVFyL7dAgp+W1LnW8M=
 github.com/onflow/flow-go/crypto v0.24.7 h1:RCLuB83At4z5wkAyUCF7MYEnPoIIOHghJaODuJyEoW0=
 github.com/onflow/flow-go/crypto v0.24.7/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230602212908-08fc6536d391 h1:6uKg0gpLKpTZKMihrsFR0Gkq++1hykzfR1tQCKuOfw4=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v0.39.4](https://github.com/onflow/cadence/releases/tag/v0.39.4)
- [onflow/flow-go-sdk v0.41.2](https://github.com/onflow/flow-go-sdk/releases/tag/v0.41.2)

