### PR TITLE
Fix error when returning empty `Array` & `Dictionary` values from scripts

### DIFF
--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -179,8 +179,13 @@ func (e *EmulatorBackend) RunScript(
 		}
 	}
 
-	staticType := runtime.ImportType(inter, result.Value.MeteredType(nil))
-	expectedType, _ := inter.ConvertStaticToSemaType(staticType)
+	staticType := runtime.ImportType(inter, result.Value.Type())
+	expectedType, err := inter.ConvertStaticToSemaType(staticType)
+	if err != nil {
+		return &stdlib.ScriptResult{
+			Error: err,
+		}
+	}
 	value, err := runtime.ImportValue(
 		inter,
 		interpreter.EmptyLocationRange,

--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -179,7 +179,15 @@ func (e *EmulatorBackend) RunScript(
 		}
 	}
 
-	value, err := runtime.ImportValue(inter, interpreter.EmptyLocationRange, e.stdlibHandler, result.Value, nil)
+	staticType := runtime.ImportType(inter, result.Value.MeteredType(nil))
+	expectedType, _ := inter.ConvertStaticToSemaType(staticType)
+	value, err := runtime.ImportValue(
+		inter,
+		interpreter.EmptyLocationRange,
+		e.stdlibHandler,
+		result.Value,
+		expectedType,
+	)
 	if err != nil {
 		return &stdlib.ScriptResult{
 			Error: err,

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -177,7 +177,7 @@ func TestExecuteScript(t *testing.T) {
 		require.NoError(t, result.Error)
 	})
 
-	t.Run("array returns", func(t *testing.T) {
+	t.Run("non-empty array returns", func(t *testing.T) {
 		t.Parallel()
 
 		const code = ` pub fun main(): [UInt64] { return [1, 2, 3]} `
@@ -207,7 +207,33 @@ func TestExecuteScript(t *testing.T) {
 		require.NoError(t, result.Error)
 	})
 
-	t.Run("dictionary returns", func(t *testing.T) {
+	t.Run("empty array returns", func(t *testing.T) {
+		t.Parallel()
+
+		const code = `pub fun main(): [UInt64] { return [] }`
+
+		testScript := fmt.Sprintf(`
+		    import Test
+
+		    pub fun test() {
+		        let blockchain = Test.newEmulatorBlockchain()
+		        let result = blockchain.executeScript("%s", [])
+
+		        Test.assert(result.status == Test.ResultStatus.succeeded)
+
+		        let resultArray = result.returnValue! as! [UInt64]
+		        Test.assert(resultArray.length == 0)
+		    }`,
+			code,
+		)
+
+		runner := NewTestRunner()
+		result, err := runner.RunTest(testScript, "test")
+		require.NoError(t, err)
+		require.NoError(t, result.Error)
+	})
+
+	t.Run("non-empty dictionary returns", func(t *testing.T) {
 		t.Parallel()
 
 		const code = ` pub fun main(): {String: Int} { return {\"foo\": 5, \"bar\": 10}} `
@@ -226,6 +252,32 @@ func TestExecuteScript(t *testing.T) {
                     assert(dictionary["foo"] == 5)
                     assert(dictionary["bar"] == 10)
             }`,
+			code,
+		)
+
+		runner := NewTestRunner()
+		result, err := runner.RunTest(testScript, "test")
+		require.NoError(t, err)
+		require.NoError(t, result.Error)
+	})
+
+	t.Run("empty dictionary returns", func(t *testing.T) {
+		t.Parallel()
+
+		const code = `pub fun main(): {String: Int} { return {} }`
+
+		testScript := fmt.Sprintf(`
+		    import Test
+
+		    pub fun test() {
+		        let blockchain = Test.newEmulatorBlockchain()
+		        let result = blockchain.executeScript("%s", [])
+
+		        Test.assert(result.status == Test.ResultStatus.succeeded)
+
+		        let dictionary = result.returnValue! as! {String: Int}
+		        Test.assert(dictionary["foo"] == nil)
+		    }`,
 			code,
 		)
 


### PR DESCRIPTION
## Description

The return errors were the following:

```bash
error: assertion failed: internal error: cannot import array: elements do not belong to the same type
```

And

```bash
error: assertion failed: cannot import dictionary: keys does not belong to the same type
```

This was due to the fact that `runtime.ImportValue` would pass `nil` for the `expectedType` parameter
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
