### PR TITLE
[LS] Ensure LS exit, even if test fails

### DIFF
--- a/languageserver/test/index.test.ts
+++ b/languageserver/test/index.test.ts
@@ -87,9 +87,11 @@ async function withConnection(f: (connection: ProtocolConnection) => Promise<voi
     connection.onError(e => console.log("err >", e))
   }
 
-  await f(connection)
-
-  await connection.sendNotification(ExitNotification.type)
+  try {
+    await f(connection)
+  } finally {
+    await connection.sendNotification(ExitNotification.type)
+  }
 }
 
 async function createTestDocument(connection: ProtocolConnection, code: string): Promise<string> {


### PR DESCRIPTION
## Description

When tests fail, the LS process keeps running an jest never exits.

This causes the CI job to run for 6 hours ... 
e.g. https://github.com/onflow/cadence-tools/actions/runs/5359904438?pr=156

Ensure the LS is always send an exit notification so it shuts down.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
