### PR TITLE
[test] Fix import replacement for new import format

### DIFF
--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -551,7 +551,14 @@ func (e *EmulatorBackend) replaceImports(code string) string {
 			continue
 		}
 
-		addressStr := fmt.Sprintf("0x%s", address)
+		var addressStr string
+		if strings.Contains(importDeclaration.String(), "from") {
+			addressStr = fmt.Sprintf("0x%s", address)
+		} else {
+			// Imports of the form `import "FungibleToken"` should be
+			// expanded to `import FungibleToken from 0xee82856bf20e2aa6`
+			addressStr = fmt.Sprintf("%s from 0x%s", location, address)
+		}
 
 		locationStart := importDeclaration.LocationPos.Offset
 

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -538,14 +538,14 @@ func TestImportBuiltinContracts(t *testing.T) {
 	`
 
 	scriptCode := `
-	    import FungibleToken from "FungibleToken"
-	    import FlowToken from "FlowToken"
-	    import FUSD from "FUSD"
-	    import NonFungibleToken from "NonFungibleToken"
-	    import MetadataViews from "MetadataViews"
-	    import ExampleNFT from "ExampleNFT"
-	    import NFTStorefrontV2 from "NFTStorefrontV2"
-	    import NFTStorefront from "NFTStorefront"
+	    import "FungibleToken"
+	    import "FlowToken"
+	    import "FUSD"
+	    import "NonFungibleToken"
+	    import "MetadataViews"
+	    import "ExampleNFT"
+	    import "NFTStorefrontV2"
+	    import "NFTStorefront"
 
 	    pub fun main(): Bool {
 	        return true


### PR DESCRIPTION
## Description

The new import format was not properly supported. For example:

```cadence
import "FUSD"
import "ExampleNFT"
```

would not work when because both contracts reside on the same address. This would crash with:

```bash
error: panic: [Error Code: 1101] error caused by: 1 error occurred:
* [Error Code: 1101] cadence runtime error: Execution failed:
error: cannot redeclare contract: `ExampleNFT` is already declared
--> efee235c05f52610b48ac1c24e3c3b9bb88fc2bbc84ad7100be68cd7326e9487:0:0
``` 
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
