### PR TITLE
Feat/add pub struct cap warning

### DIFF
--- a/lint/warn_implicit_capability_leak_via_struct.go
+++ b/lint/warn_implicit_capability_leak_via_struct.go
@@ -1,0 +1,98 @@
+package lint
+
+import (
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/tools/analysis"
+)
+
+/*
+ * Cadence-lint - The Cadence linter
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var ImplicitCapabilityLeakViaStruct = (func() *analysis.Analyzer {
+
+	return &analysis.Analyzer{
+		Description: "Detects potential capability leak via public struct",
+		Requires: []*analysis.Analyzer{
+			analysis.InspectorAnalyzer,
+		},
+		Run: func(pass *analysis.Pass) interface{} {
+			inspector := pass.ResultOf[analysis.InspectorAnalyzer].(*ast.Inspector)
+
+			location := pass.Program.Location
+			report := pass.Report
+
+			var structIdentifier *string
+			inspector.Preorder(
+				[]ast.Element{(*ast.CompositeDeclaration)(nil)},
+				func(element ast.Element) {
+					switch declaration := element.(type) {
+					case *ast.CompositeDeclaration:
+						{
+							if declaration.CompositeKind == common.CompositeKindStructure {
+								for _, d := range declaration.Members.Declarations() {
+									if fd, ok := d.(*ast.FieldDeclaration); ok {
+										if nd, ok := fd.TypeAnnotation.Type.(*ast.NominalType); ok {
+											if nd.Identifier.Identifier == "Capability" && fd.Access == ast.AccessPublic {
+												structIdentifier = &declaration.Identifier.Identifier
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+			)
+			
+			if structIdentifier != nil {
+				inspector.Preorder(
+					[]ast.Element{(*ast.FieldDeclaration)(nil)},
+					func(element ast.Element) {
+						switch declaration := element.(type) {
+						case *ast.FieldDeclaration:
+							{
+								if nt, ok := declaration.TypeAnnotation.Type.(*ast.NominalType); ok {
+									if nt.Identifier.Identifier == *structIdentifier && declaration.Access == ast.AccessPublic {
+										report(
+											analysis.Diagnostic{
+												Location: location,
+												Range:    ast.NewRangeFromPositioned(nil, element),
+												Category: ReplacementCategory,
+												Message:  "capability might be leaking via public struct field",
+											},
+										)
+									}
+								}
+							}
+						}
+					},
+				)
+			}
+
+			return nil
+		},
+	}
+})()
+
+func init() {
+	RegisterAnalyzer(
+		"implicit-capability-leak-through-struct",
+		ImplicitCapabilityLeakViaStruct,
+	)
+}

--- a/lint/warn_implicit_capability_leak_via_struct_test.go
+++ b/lint/warn_implicit_capability_leak_via_struct_test.go
@@ -66,8 +66,8 @@ func TestImplicitCapabilityLeakViaStruct(t *testing.T) {
 			[]analysis.Diagnostic{
 				{
 					Range: ast.Range{
-						StartPos: ast.Position{Offset: 383, Line: 20, Column: 5},
-						EndPos:   ast.Position{Offset: 416, Line: 20, Column: 38},
+						StartPos: ast.Position{Offset: 312, Line: 18, Column: 5},
+						EndPos:   ast.Position{Offset: 345, Line: 18, Column: 38},
 					},
 					Location: testLocation,
 					Category: lint.ReplacementCategory,
@@ -85,14 +85,31 @@ func TestImplicitCapabilityLeakViaStruct(t *testing.T) {
 		diagnostics := testAnalyzers(t,
 			`
 			pub contract MyContract {
-				priv let myCapArray: [Capability]
-	
-				init() {
-	 				 self.myCapArray = []
-				}
+			   pub resource Counter {
+				 priv var count: Int
+			
+				 init(count: Int) {
+				   self.count = count
+				 }
+			   }
+		
+			   pub struct ContractData {
+				   pub var owner: Capability
+				   init(cap: Capability) {
+					   self.owner = cap
+				   }
+			   }
+		
+               priv var contractData: ContractData
+		
+			   init(){
+				   self.contractData = ContractData(cap:
+					   self.account.getCapability<&Counter>(/public/counter)
+				   )
+			   }
 			}
 			`,
-			lint.ImplicitCapabilityLeak,
+			lint.ImplicitCapabilityLeakViaStruct,
 		)
 
 		require.Equal(

--- a/lint/warn_implicit_capability_leak_via_struct_test.go
+++ b/lint/warn_implicit_capability_leak_via_struct_test.go
@@ -1,0 +1,104 @@
+/*
+ * Cadence-lint - The Cadence linter
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lint_test
+
+import (
+	"testing"
+
+	"github.com/onflow/cadence-tools/lint"
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/tools/analysis"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImplicitCapabilityLeakViaStruct(t *testing.T) {
+
+	t.Parallel()
+	t.Run("leak via struct field", func(t *testing.T) {
+
+		diagnostics := testAnalyzers(t,
+			`
+		pub contract MyContract {
+		   pub resource Counter {
+		     priv var count: Int
+		
+		     init(count: Int) {
+		       self.count = count
+		     }
+		   }
+		
+		   pub struct ContractData {
+			   pub var owner: Capability
+		       init(cap: Capability) {
+		           self.owner = cap
+		       }
+		   }
+		
+		   pub var contractData: ContractData
+		
+		   init(){
+		       self.contractData = ContractData(cap:
+		           self.account.getCapability<&Counter>(/public/counter)
+		       )
+		   }
+		}`,
+			lint.ImplicitCapabilityLeakViaStruct,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic{
+				{
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 383, Line: 20, Column: 5},
+						EndPos:   ast.Position{Offset: 416, Line: 20, Column: 38},
+					},
+					Location: testLocation,
+					Category: lint.ReplacementCategory,
+					Message:  "capability might be leaking via public struct field",
+				},
+			},
+			diagnostics,
+		)
+	})
+
+	t.Run("valid", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+			pub contract MyContract {
+				priv let myCapArray: [Capability]
+	
+				init() {
+	 				 self.myCapArray = []
+				}
+			}
+			`,
+			lint.ImplicitCapabilityLeak,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic(nil),
+			diagnostics,
+		)
+	})
+}


### PR DESCRIPTION
<!--
Prefix the title with one of:
[LS] 
[test]
[lint]
-->

Closes #16 

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
Warn about potential Capability leak via public struct fields. 

Example: 
```
pub contract MyContract {
		  
		   pub struct ContractData {
		       pub var owner: Capability
		       // ....
		   }
		
		   pub var contractData: ContractData
		}
```
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
