### PR TITLE
[LS] Update to cadence-tools/lint v0.10.1

### DIFF
--- a/languageserver/go.mod
+++ b/languageserver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/mattn/go-isatty v0.0.19
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onflow/cadence v0.39.14
-	github.com/onflow/cadence-tools/lint v0.9.0
+	github.com/onflow/cadence-tools/lint v0.10.1
 	github.com/onflow/flow-cli/flowkit v1.3.2-0.20230714155736-8c42ef6a9f45
 	github.com/onflow/flow-go-sdk v0.41.9
 	github.com/sourcegraph/jsonrpc2 v0.1.0

--- a/languageserver/go.sum
+++ b/languageserver/go.sum
@@ -539,8 +539,8 @@ github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVF
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
 github.com/onflow/cadence v0.39.14 h1:YoR3YFUga49rqzVY1xwI6I2ZDBmvwGh13jENncsleC8=
 github.com/onflow/cadence v0.39.14/go.mod h1:OIJLyVBPa339DCBQXBfGaorT4tBjQh9gSKe+ZAIyyh0=
-github.com/onflow/cadence-tools/lint v0.9.0 h1:hGYL1608rhk1ALCFShg/4BDacmUYk54nfIC7tstEIoY=
-github.com/onflow/cadence-tools/lint v0.9.0/go.mod h1:mmULh2XMBId55Flv9gaMGThqgDTSMkt96arfpqeaz8I=
+github.com/onflow/cadence-tools/lint v0.10.1 h1:EAtLDiwtA7gnZ1grwmQkiCu487dTpH1H9v57UaoBPGk=
+github.com/onflow/cadence-tools/lint v0.10.1/go.mod h1:Rz3QhLseu6SnvZgBvyeJ0qzzz38Wxlev1lFwLiZtoPQ=
 github.com/onflow/flow-cli/flowkit v1.3.2-0.20230714155736-8c42ef6a9f45 h1:ffkBeDytgqWyAe2W1DNjHiYY0vn0WnEoEmZZtxTPnBg=
 github.com/onflow/flow-cli/flowkit v1.3.2-0.20230714155736-8c42ef6a9f45/go.mod h1:MXBfHLOB7+QPTFs+HfdsC3/KujyISELCAX0L4Wzz8Jc=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.3 h1:wV+gcgOY0oJK4HLZQYQoK+mm09rW1XSxf83yqJwj0n4=


### PR DESCRIPTION
## Description

The auto-update PR https://github.com/onflow/cadence-tools/pull/173 somehow didn't update the lint version in LS.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
