### PR TITLE
[test] Cadence testing framework improvements

### DIFF
--- a/test/blockchain_helpers.cdc
+++ b/test/blockchain_helpers.cdc
@@ -1,0 +1,67 @@
+import Test
+
+/// Returns the Flow token balance for the given account.
+///
+pub fun getFlowBalance(
+    for account: Test.Account,
+    blockchain: Test.Blockchain
+): UFix64 {
+    let script = Test.readFile("get_flow_balance.cdc")
+    let scriptResult = blockchain.executeScript(script, [account.address])
+
+    if scriptResult.status == Test.ResultStatus.failed {
+        panic(scriptResult.error!.message)
+    }
+    return scriptResult.returnValue! as! UFix64
+}
+
+/// Returns the current block height of the blockchain.
+///
+pub fun getCurrentBlockHeight(blockchain: Test.Blockchain): UInt64 {
+    let script = Test.readFile("get_current_block_height.cdc")
+    let scriptResult = blockchain.executeScript(script, [])
+
+    if scriptResult.status == Test.ResultStatus.failed {
+        panic(scriptResult.error!.message)
+    }
+    return scriptResult.returnValue! as! UInt64
+}
+
+/// Mints the given amount of Flow tokens to a specified test account.
+/// The transaction is authorized and signed by the service account.
+/// Returns the result of the transaction.
+///
+pub fun mintFlow(
+    to receiver: Test.Account,
+    amount: UFix64,
+    blockchain: Test.Blockchain
+): Test.TransactionResult {
+    let code = Test.readFile("mint_flow.cdc")
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [blockchain.serviceAccount().address],
+        signers: [],
+        arguments: [receiver.address, amount]
+    )
+
+    return blockchain.executeTransaction(tx)
+}
+
+/// Burns the specified amount of Flow tokens for the given
+/// test account. Returns the result of the transaction.
+///
+pub fun burnFlow(
+    from account: Test.Account,
+    amount: UFix64,
+    blockchain: Test.Blockchain
+): Test.TransactionResult {
+    let code = Test.readFile("burn_flow.cdc")
+    let tx = Test.Transaction(
+        code: code,
+        authorizers: [account.address],
+        signers: [account],
+        arguments: [amount]
+    )
+
+    return blockchain.executeTransaction(tx)
+}

--- a/test/blockchain_helpers.cdc
+++ b/test/blockchain_helpers.cdc
@@ -10,7 +10,7 @@ pub struct BlockchainHelpers {
     /// Returns the current block height of the blockchain.
     ///
     pub fun getCurrentBlockHeight(): UInt64 {
-        let script = Test.readFile("\u{0}helper/get_current_block_height.cdc")
+        let script = self.readFile("get_current_block_height.cdc")
         let scriptResult = self.blockchain.executeScript(script, [])
 
         if scriptResult.status == Test.ResultStatus.failed {
@@ -22,7 +22,7 @@ pub struct BlockchainHelpers {
     /// Returns the Flow token balance for the given account.
     ///
     pub fun getFlowBalance(for account: Test.Account): UFix64 {
-        let script = Test.readFile("\u{0}helper/get_flow_balance.cdc")
+        let script = self.readFile("get_flow_balance.cdc")
         let scriptResult = self.blockchain.executeScript(script, [account.address])
 
         if scriptResult.status == Test.ResultStatus.failed {
@@ -39,7 +39,7 @@ pub struct BlockchainHelpers {
         to receiver: Test.Account,
         amount: UFix64
     ): Test.TransactionResult {
-        let code = Test.readFile("\u{0}helper/mint_flow.cdc")
+        let code = self.readFile("mint_flow.cdc")
         let tx = Test.Transaction(
             code: code,
             authorizers: [self.blockchain.serviceAccount().address],
@@ -57,7 +57,7 @@ pub struct BlockchainHelpers {
         from account: Test.Account,
         amount: UFix64
     ): Test.TransactionResult {
-        let code = Test.readFile("\u{0}helper/burn_flow.cdc")
+        let code = self.readFile("burn_flow.cdc")
         let tx = Test.Transaction(
             code: code,
             authorizers: [account.address],
@@ -66,5 +66,15 @@ pub struct BlockchainHelpers {
         )
 
         return self.blockchain.executeTransaction(tx)
+    }
+
+    /// Reads the code for the script/transaction with the given
+    /// file name and returns its content as a String.
+    ///
+    access(self)
+    fun readFile(_ name: String): String {
+        // The "\u{0}helper/" prefix is used in order to prevent
+        // conflicts with user-defined scripts/transactions.
+        return Test.readFile("\u{0}helper/".concat(name))
     }
 }

--- a/test/blockchain_helpers.cdc
+++ b/test/blockchain_helpers.cdc
@@ -1,67 +1,70 @@
 import Test
 
-/// Returns the Flow token balance for the given account.
-///
-pub fun getFlowBalance(
-    for account: Test.Account,
-    blockchain: Test.Blockchain
-): UFix64 {
-    let script = Test.readFile("get_flow_balance.cdc")
-    let scriptResult = blockchain.executeScript(script, [account.address])
+pub struct BlockchainHelpers {
+    pub let blockchain: Test.Blockchain
 
-    if scriptResult.status == Test.ResultStatus.failed {
-        panic(scriptResult.error!.message)
+    init(blockchain: Test.Blockchain) {
+        self.blockchain = blockchain
     }
-    return scriptResult.returnValue! as! UFix64
-}
 
-/// Returns the current block height of the blockchain.
-///
-pub fun getCurrentBlockHeight(blockchain: Test.Blockchain): UInt64 {
-    let script = Test.readFile("get_current_block_height.cdc")
-    let scriptResult = blockchain.executeScript(script, [])
+    /// Returns the current block height of the blockchain.
+    ///
+    pub fun getCurrentBlockHeight(): UInt64 {
+        let script = Test.readFile("\u{0}helper/get_current_block_height.cdc")
+        let scriptResult = self.blockchain.executeScript(script, [])
 
-    if scriptResult.status == Test.ResultStatus.failed {
-        panic(scriptResult.error!.message)
+        if scriptResult.status == Test.ResultStatus.failed {
+            panic(scriptResult.error!.message)
+        }
+        return scriptResult.returnValue! as! UInt64
     }
-    return scriptResult.returnValue! as! UInt64
-}
 
-/// Mints the given amount of Flow tokens to a specified test account.
-/// The transaction is authorized and signed by the service account.
-/// Returns the result of the transaction.
-///
-pub fun mintFlow(
-    to receiver: Test.Account,
-    amount: UFix64,
-    blockchain: Test.Blockchain
-): Test.TransactionResult {
-    let code = Test.readFile("mint_flow.cdc")
-    let tx = Test.Transaction(
-        code: code,
-        authorizers: [blockchain.serviceAccount().address],
-        signers: [],
-        arguments: [receiver.address, amount]
-    )
+    /// Returns the Flow token balance for the given account.
+    ///
+    pub fun getFlowBalance(for account: Test.Account): UFix64 {
+        let script = Test.readFile("\u{0}helper/get_flow_balance.cdc")
+        let scriptResult = self.blockchain.executeScript(script, [account.address])
 
-    return blockchain.executeTransaction(tx)
-}
+        if scriptResult.status == Test.ResultStatus.failed {
+            panic(scriptResult.error!.message)
+        }
+        return scriptResult.returnValue! as! UFix64
+    }
 
-/// Burns the specified amount of Flow tokens for the given
-/// test account. Returns the result of the transaction.
-///
-pub fun burnFlow(
-    from account: Test.Account,
-    amount: UFix64,
-    blockchain: Test.Blockchain
-): Test.TransactionResult {
-    let code = Test.readFile("burn_flow.cdc")
-    let tx = Test.Transaction(
-        code: code,
-        authorizers: [account.address],
-        signers: [account],
-        arguments: [amount]
-    )
+    /// Mints the given amount of Flow tokens to a specified test account.
+    /// The transaction is authorized and signed by the service account.
+    /// Returns the result of the transaction.
+    ///
+    pub fun mintFlow(
+        to receiver: Test.Account,
+        amount: UFix64
+    ): Test.TransactionResult {
+        let code = Test.readFile("\u{0}helper/mint_flow.cdc")
+        let tx = Test.Transaction(
+            code: code,
+            authorizers: [self.blockchain.serviceAccount().address],
+            signers: [],
+            arguments: [receiver.address, amount]
+        )
 
-    return blockchain.executeTransaction(tx)
+        return self.blockchain.executeTransaction(tx)
+    }
+
+    /// Burns the specified amount of Flow tokens for the given
+    /// test account. Returns the result of the transaction.
+    ///
+    pub fun burnFlow(
+        from account: Test.Account,
+        amount: UFix64
+    ): Test.TransactionResult {
+        let code = Test.readFile("\u{0}helper/burn_flow.cdc")
+        let tx = Test.Transaction(
+            code: code,
+            authorizers: [account.address],
+            signers: [account],
+            arguments: [amount]
+        )
+
+        return self.blockchain.executeTransaction(tx)
+    }
 }

--- a/test/blockchain_helpers.go
+++ b/test/blockchain_helpers.go
@@ -1,0 +1,88 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/parser"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/stdlib"
+)
+
+//go:embed blockchain_helpers.cdc
+var BlockchainHelpers []byte
+
+func BlockchainHelpersChecker() *sema.Checker {
+	program, err := parser.ParseProgram(
+		nil,
+		BlockchainHelpers,
+		parser.Config{},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	importHandler := func(
+		checker *sema.Checker,
+		importedLocation common.Location,
+		importRange ast.Range,
+	) (sema.Import, error) {
+		var elaboration *sema.Elaboration
+		switch importedLocation {
+		case stdlib.TestContractLocation:
+			testChecker := stdlib.GetTestContractType().Checker
+			elaboration = testChecker.Elaboration
+		default:
+			return nil, fmt.Errorf("import not supported")
+		}
+
+		return sema.ElaborationImport{
+			Elaboration: elaboration,
+		}, nil
+	}
+
+	activation := sema.NewVariableActivation(sema.BaseValueActivation)
+	activation.DeclareValue(stdlib.AssertFunction)
+	activation.DeclareValue(stdlib.PanicFunction)
+
+	checker, err := sema.NewChecker(
+		program,
+		common.IdentifierLocation("BlockchainHelpers"),
+		nil,
+		&sema.Config{
+			BaseValueActivation: activation,
+			AccessCheckMode:     sema.AccessCheckModeStrict,
+			ImportHandler:       importHandler,
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	err = checker.Check()
+	if err != nil {
+		panic(err)
+	}
+
+	return checker
+}

--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -46,6 +46,10 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// The "\x00helper/" prefix is used in order to prevent
+// conflicts with user-defined scripts/transactions.
+const helperFilePrefix = "\x00helper/"
+
 var _ stdlib.TestFramework = &EmulatorBackend{}
 
 // EmulatorBackend is the emulator-backed implementation of the interpreter.TestFramework.
@@ -475,19 +479,19 @@ func (e *EmulatorBackend) DeployContract(
 
 func (e *EmulatorBackend) ReadFile(path string) (string, error) {
 	// These are the scripts/transactions used by the
-	// BlockchainHelpers file. The "\x00helper/" prefix is
-	// used in order to prevent conflicts with user-defined
-	// scripts/transactions.
-	filename := strings.TrimPrefix(path, "\x00helper/")
-	switch filename {
-	case "mint_flow.cdc":
-		return string(MintFlowTransaction), nil
-	case "get_flow_balance.cdc":
-		return string(GetFlowBalance), nil
-	case "get_current_block_height.cdc":
-		return string(GetCurrentBlockHeight), nil
-	case "burn_flow.cdc":
-		return string(BurnFlow), nil
+	// BlockchainHelpers file.
+	if strings.HasPrefix(path, helperFilePrefix) {
+		filename := strings.TrimPrefix(path, helperFilePrefix)
+		switch filename {
+		case "mint_flow.cdc":
+			return string(MintFlowTransaction), nil
+		case "get_flow_balance.cdc":
+			return string(GetFlowBalance), nil
+		case "get_current_block_height.cdc":
+			return string(GetCurrentBlockHeight), nil
+		case "burn_flow.cdc":
+			return string(BurnFlow), nil
+		}
 	}
 
 	if e.fileResolver == nil {

--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -474,6 +474,18 @@ func (e *EmulatorBackend) DeployContract(
 }
 
 func (e *EmulatorBackend) ReadFile(path string) (string, error) {
+	// These are the scripts/transactions used by the
+	// BlockchainHelpers file.
+	if path == "mint_flow.cdc" {
+		return string(MintFlowTransaction), nil
+	} else if path == "get_flow_balance.cdc" {
+		return string(GetFlowBalance), nil
+	} else if path == "get_current_block_height.cdc" {
+		return string(GetCurrentBlockHeight), nil
+	} else if path == "burn_flow.cdc" {
+		return string(BurnFlow), nil
+	}
+
 	if e.fileResolver == nil {
 		return "", FileResolverNotProvidedError{}
 	}

--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -475,16 +475,18 @@ func (e *EmulatorBackend) DeployContract(
 
 func (e *EmulatorBackend) ReadFile(path string) (string, error) {
 	// These are the scripts/transactions used by the
-	// BlockchainHelpers file. The null character is
+	// BlockchainHelpers file. The "\x00helper/" prefix is
 	// used in order to prevent conflicts with user-defined
 	// scripts/transactions.
-	if path == "\x00helper/mint_flow.cdc" {
+	filename := strings.TrimPrefix(path, "\x00helper/")
+	switch filename {
+	case "mint_flow.cdc":
 		return string(MintFlowTransaction), nil
-	} else if path == "\x00helper/get_flow_balance.cdc" {
+	case "get_flow_balance.cdc":
 		return string(GetFlowBalance), nil
-	} else if path == "\x00helper/get_current_block_height.cdc" {
+	case "get_current_block_height.cdc":
 		return string(GetCurrentBlockHeight), nil
-	} else if path == "\x00helper/burn_flow.cdc" {
+	case "burn_flow.cdc":
 		return string(BurnFlow), nil
 	}
 

--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -475,14 +475,16 @@ func (e *EmulatorBackend) DeployContract(
 
 func (e *EmulatorBackend) ReadFile(path string) (string, error) {
 	// These are the scripts/transactions used by the
-	// BlockchainHelpers file.
-	if path == "mint_flow.cdc" {
+	// BlockchainHelpers file. The null character is
+	// used in order to prevent conflicts with user-defined
+	// scripts/transactions.
+	if path == "\x00helper/mint_flow.cdc" {
 		return string(MintFlowTransaction), nil
-	} else if path == "get_flow_balance.cdc" {
+	} else if path == "\x00helper/get_flow_balance.cdc" {
 		return string(GetFlowBalance), nil
-	} else if path == "get_current_block_height.cdc" {
+	} else if path == "\x00helper/get_current_block_height.cdc" {
 		return string(GetCurrentBlockHeight), nil
-	} else if path == "burn_flow.cdc" {
+	} else if path == "\x00helper/burn_flow.cdc" {
 		return string(BurnFlow), nil
 	}
 

--- a/test/scripts.go
+++ b/test/scripts.go
@@ -1,0 +1,29 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	_ "embed"
+)
+
+//go:embed scripts/get_flow_balance.cdc
+var GetFlowBalance []byte
+
+//go:embed scripts/get_current_block_height.cdc
+var GetCurrentBlockHeight []byte

--- a/test/scripts/get_current_block_height.cdc
+++ b/test/scripts/get_current_block_height.cdc
@@ -1,0 +1,3 @@
+pub fun main(): UInt64 {
+    return getCurrentBlock().height
+}

--- a/test/scripts/get_flow_balance.cdc
+++ b/test/scripts/get_flow_balance.cdc
@@ -1,0 +1,11 @@
+import "FungibleToken"
+import "FlowToken"
+
+pub fun main(address: Address): UFix64 {
+    let balanceRef = getAccount(address)
+        .getCapability(/public/flowTokenBalance)
+        .borrow<&FlowToken.Vault{FungibleToken.Balance}>()
+        ?? panic("Could not borrow FungibleToken.Balance reference")
+
+    return balanceRef.balance
+}

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -1799,7 +1799,6 @@ func TestErrors(t *testing.T) {
 
                 let result = blockchain.executeTransaction(tx2)!
 
-                Test.assertError(result, errorMessage: "some error")
                 if result.status == Test.ResultStatus.failed {
                     panic(result.error!.message)
                 }
@@ -2815,13 +2814,14 @@ func TestGetAccountFlowBalance(t *testing.T) {
         import BlockchainHelpers
 
         pub let blockchain = Test.newEmulatorBlockchain()
+        pub let helpers = BlockchainHelpers(blockchain: blockchain)
 
         pub fun testGetFlowBalance() {
             // Arrange
             let account = blockchain.serviceAccount()
 
             // Act
-            let balance = getFlowBalance(for: account, blockchain: blockchain)
+            let balance = helpers.getFlowBalance(for: account)
 
             // Assert
             Test.assertEqual(1000000000.0, balance)
@@ -2843,17 +2843,18 @@ func TestGetCurrentBlockHeight(t *testing.T) {
         import BlockchainHelpers
 
         pub let blockchain = Test.newEmulatorBlockchain()
+        pub let helpers = BlockchainHelpers(blockchain: blockchain)
 
         pub fun testGetCurrentBlockHeight() {
             // Act
-            let height = getCurrentBlockHeight(blockchain: blockchain)
+            let height = helpers.getCurrentBlockHeight()
 
             // Assert
             Test.expect(height, Test.beGreaterThan(1 as UInt64))
 
             // Act
             blockchain.commitBlock()
-            let newHeight = getCurrentBlockHeight(blockchain: blockchain)
+            let newHeight = helpers.getCurrentBlockHeight()
 
             // Assert
             Test.assertEqual(newHeight, height + 1)
@@ -2875,16 +2876,17 @@ func TestMintFlow(t *testing.T) {
         import BlockchainHelpers
 
         pub let blockchain = Test.newEmulatorBlockchain()
+        pub let helpers = BlockchainHelpers(blockchain: blockchain)
 
         pub fun testMintFlow() {
             // Arrange
             let account = blockchain.createAccount()
 
             // Act
-            mintFlow(to: account, amount: 1500.0, blockchain: blockchain)
+            helpers.mintFlow(to: account, amount: 1500.0)
 
             // Assert
-            let balance = getFlowBalance(for: account, blockchain: blockchain)
+            let balance = helpers.getFlowBalance(for: account)
             Test.assertEqual(1500.0, balance)
         }
 	`
@@ -2904,23 +2906,24 @@ func TestBurnFlow(t *testing.T) {
         import BlockchainHelpers
 
         pub let blockchain = Test.newEmulatorBlockchain()
+        pub let helpers = BlockchainHelpers(blockchain: blockchain)
 
         pub fun testBurnFlow() {
             // Arrange
             let account = blockchain.createAccount()
 
             // Act
-            mintFlow(to: account, amount: 1500.0, blockchain: blockchain)
+            helpers.mintFlow(to: account, amount: 1500.0)
 
             // Assert
-            var balance = getFlowBalance(for: account, blockchain: blockchain)
+            var balance = helpers.getFlowBalance(for: account)
             Test.assertEqual(1500.0, balance)
 
             // Act
-            burnFlow(from: account, amount: 500.0, blockchain: blockchain)
+            helpers.burnFlow(from: account, amount: 500.0)
 
             // Assert
-            balance = getFlowBalance(for: account, blockchain: blockchain)
+            balance = helpers.getFlowBalance(for: account)
             Test.assertEqual(1000.0, balance)
         }
 	`
@@ -2984,13 +2987,14 @@ func TestServiceAccount(t *testing.T) {
             import BlockchainHelpers
 
             pub let blockchain = Test.newEmulatorBlockchain()
+            pub let helpers = BlockchainHelpers(blockchain: blockchain)
 
             pub fun testGetServiceAccountBalance() {
                 // Arrange
                 let account = blockchain.serviceAccount()
 
                 // Act
-                let balance = getFlowBalance(for: account, blockchain: blockchain)
+                let balance = helpers.getFlowBalance(for: account)
 
                 // Assert
                 Test.assertEqual(1000000000.0, balance)
@@ -3014,7 +3018,7 @@ func TestServiceAccount(t *testing.T) {
                 Test.expect(txResult, Test.beSucceeded())
 
                 // Assert
-                let balance = getFlowBalance(for: receiver, blockchain: blockchain)
+                let balance = helpers.getFlowBalance(for: receiver)
                 Test.assertEqual(1500.0, balance)
             }
 		`
@@ -4080,28 +4084,27 @@ func TestBlockchainReset(t *testing.T) {
         import BlockchainHelpers
 
         pub let blockchain = Test.newEmulatorBlockchain()
+        pub let helpers = BlockchainHelpers(blockchain: blockchain)
 
         pub fun testBlockchainReset() {
             // Arrange
             let account = blockchain.createAccount()
-            var balance = getFlowBalance(for: account, blockchain: blockchain)
+            var balance = helpers.getFlowBalance(for: account)
             Test.assertEqual(0.0, balance)
 
-            let height = getCurrentBlockHeight(blockchain: blockchain)
+            let height = helpers.getCurrentBlockHeight()
 
-            mintFlow(to: account, amount: 1500.0, blockchain: blockchain)
+            helpers.mintFlow(to: account, amount: 1500.0)
 
-            balance = getFlowBalance(for: account, blockchain: blockchain)
+            balance = helpers.getFlowBalance(for: account)
             Test.assertEqual(1500.0, balance)
-            Test.assertEqual(getCurrentBlockHeight(blockchain: blockchain), height + 1)
+            Test.assertEqual(helpers.getCurrentBlockHeight(), height + 1)
 
             // Act
-            blockchain.reset(to: height)
+            blockchain.reset()
 
             // Assert
-            balance = getFlowBalance(for: account, blockchain: blockchain)
-            Test.assertEqual(0.0, balance)
-            Test.assertEqual(getCurrentBlockHeight(blockchain: blockchain), height)
+            Test.assertEqual(helpers.getCurrentBlockHeight(), 0 as UInt64)
         }
 	`
 

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -4119,3 +4119,51 @@ func TestBlockchainHelpersChecker(t *testing.T) {
 	err := checker.Check()
 	assert.NoError(t, err)
 }
+
+func TestTestFunctionValidSignature(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with argument", func(t *testing.T) {
+		t.Parallel()
+
+		const testCode = `
+            import Test
+
+            pub fun testValidSignature() {
+                Test.assertEqual(2, 5 - 3)
+            }
+
+            pub fun testInvalidSignature(prefix: String) {
+                Test.assertEqual(2, 5 - 3)
+            }
+		`
+
+		runner := NewTestRunner()
+
+		_, err := runner.RunTests(testCode)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "test functions should have no arguments")
+	})
+
+	t.Run("with return value", func(t *testing.T) {
+		t.Parallel()
+
+		const testCode = `
+            import Test
+
+            pub fun testValidSignature() {
+                Test.assertEqual(2, 5 - 3)
+            }
+
+            pub fun testInvalidSignature(): Bool {
+                return 2 == (5 - 3)
+            }
+		`
+
+		runner := NewTestRunner()
+
+		_, err := runner.RunTests(testCode)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "test functions should have no return values")
+	})
+}

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -398,8 +398,21 @@ func (r *TestRunner) parseCheckAndInterpret(script string) (*interpreter.Program
 		return nil, nil, err
 	}
 
-	// TODO: validate test function signature
-	//   e.g: no return values, no arguments, etc.
+	for _, funcDecl := range program.Program.FunctionDeclarations() {
+		funcName := funcDecl.Identifier.Identifier
+
+		if !strings.HasPrefix(funcName, testFunctionPrefix) {
+			continue
+		}
+
+		if !funcDecl.ParameterList.IsEmpty() {
+			return nil, nil, fmt.Errorf("test functions should have no arguments")
+		}
+
+		if funcDecl.ReturnTypeAnnotation != nil {
+			return nil, nil, fmt.Errorf("test functions should have no return values")
+		}
+	}
 
 	// Set the storage after checking, because `ParseAndCheckProgram` clears the storage.
 	env.InterpreterConfig.Storage = runtime.NewStorage(ctx.Interface, nil)

--- a/test/transactions.go
+++ b/test/transactions.go
@@ -1,0 +1,29 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	_ "embed"
+)
+
+//go:embed transactions/mint_flow.cdc
+var MintFlowTransaction []byte
+
+//go:embed transactions/burn_flow.cdc
+var BurnFlow []byte

--- a/test/transactions/burn_flow.cdc
+++ b/test/transactions/burn_flow.cdc
@@ -1,0 +1,13 @@
+import "FungibleToken"
+import "FlowToken"
+
+transaction(amount: UFix64) {
+    prepare(account: AuthAccount) {
+        let flowVault = account.borrow<&FlowToken.Vault>(
+            from: /storage/flowTokenVault
+        ) ?? panic("Could not borrow BlpToken.Vault reference)")
+
+        let tokens <- flowVault.withdraw(amount: amount)
+        destroy <- tokens
+    }
+}

--- a/test/transactions/mint_flow.cdc
+++ b/test/transactions/mint_flow.cdc
@@ -1,0 +1,18 @@
+import "FungibleToken"
+import "FlowToken"
+
+transaction(receiver: Address, amount: UFix64) {
+    prepare(account: AuthAccount) {
+        let flowVault = account.borrow<&FlowToken.Vault>(
+            from: /storage/flowTokenVault
+        ) ?? panic("Could not borrow BlpToken.Vault reference")
+
+        let receiverRef = getAccount(receiver)
+            .getCapability(/public/flowTokenReceiver)
+            .borrow<&FlowToken.Vault{FungibleToken.Receiver}>()
+            ?? panic("Could not borrow FungibleToken.Receiver reference")
+
+        let tokens <- flowVault.withdraw(amount: amount)
+        receiverRef.deposit(from: <- tokens)
+    }
+}


### PR DESCRIPTION
Closes https://github.com/onflow/cadence-tools/issues/171

## Description

Adding tests & API changes for the following improvements:
- Expose current block information, such as **block height**
- Expose **balance** for test accounts
- Add helper function to **mint** FLOW to a test account
- Add helper function to **burn** FLOW from a test account
- **Validate test function signature**, no arguments or return values

Sample usage:

```cadence
import Test
import BlockchainHelpers

pub let blockchain = Test.newEmulatorBlockchain()
pub let helpers = BlockchainHelpers(blockchain: blockchain)
pub let account = blockchain.createAccount()

// Retrieve current block height
pub let height = helpers.getCurrentBlockHeight()

// Retrieve the Flow token balance of a test account
pub let balance = helpers.getFlowBalance(for: account)

// Mint a given amount of Flow tokens to a specified test account
helpers.mintFlow(to: account, amount: 1500.0)

// Burn a given amount of Flow tokens from a specified test account
helpers.burnFlow(from: account, amount: 500.0)
```
______

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
