### PR TITLE
[test] Add assertions to verify loading of standard library flow events

### DIFF
--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -745,10 +745,18 @@ func TestCreateAccount(t *testing.T) {
         pub fun test() {
             let blockchain = Test.newEmulatorBlockchain()
             let account = blockchain.createAccount()
+
+            let typ = CompositeType("flow.AccountCreated")!
+            let events = blockchain.eventsOfType(typ)
+            Test.assertEqual(1, events.length)
         }
 	`
 
-	runner := NewTestRunner()
+	importResolver := func(location common.Location) (string, error) {
+		return "", nil
+	}
+
+	runner := NewTestRunner().WithImportResolver(importResolver)
 	result, err := runner.RunTest(code, "test")
 	require.NoError(t, err)
 	require.NoError(t, result.Error)


### PR DESCRIPTION
Context: https://github.com/onflow/cadence-tools/issues/172
Related PR: https://github.com/onflow/cadence/pull/2717

## Description

Adds some assertions to verify that loading of standard library flow events works as expected.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
