### PR TITLE
[test] Allow test scripts to import types from deployed contracts

### DIFF
--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -2957,7 +2957,7 @@ func TestServiceAccount(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(
 			t,
-			"0xf8d6e0586b0a20c7",
+			"0x0000000000000001",
 			serviceAccount.Address.HexWithPrefix(),
 		)
 	})
@@ -2977,7 +2977,7 @@ func TestServiceAccount(t *testing.T) {
                 // Assert
                 Test.assertEqual(Type<Address>(), account.address.getType())
                 Test.assertEqual(Type<PublicKey>(), account.publicKey.getType())
-                Test.assertEqual(Address(0xf8d6e0586b0a20c7), account.address)
+                Test.assertEqual(Address(0x0000000000000001), account.address)
             }
 		`
 
@@ -3377,7 +3377,7 @@ func TestCoverageReportForIntegrationTests(t *testing.T) {
 	assert.Equal(t, result2.TestName, "testAddSpecialNumber")
 	require.NoError(t, result2.Error)
 
-	address, err := common.HexToAddress("0x01cf0e2f2f715450")
+	address, err := common.HexToAddress("0x0000000000000005")
 	require.NoError(t, err)
 	location := common.AddressLocation{
 		Address: address,
@@ -3400,25 +3400,25 @@ func TestCoverageReportForIntegrationTests(t *testing.T) {
 	assert.ElementsMatch(
 		t,
 		[]string{
-			"A.0ae53cb6e3f42a79.FlowToken",
-			"A.ee82856bf20e2aa6.FungibleToken",
-			"A.e5a8b7f23e8b548f.FlowFees",
-			"A.f8d6e0586b0a20c7.FlowStorageFees",
-			"A.f8d6e0586b0a20c7.FlowServiceAccount",
-			"A.f8d6e0586b0a20c7.FlowClusterQC",
-			"A.f8d6e0586b0a20c7.FlowDKG",
-			"A.f8d6e0586b0a20c7.FlowEpoch",
-			"A.f8d6e0586b0a20c7.FlowIDTableStaking",
-			"A.f8d6e0586b0a20c7.FlowStakingCollection",
-			"A.f8d6e0586b0a20c7.LockedTokens",
-			"A.f8d6e0586b0a20c7.NodeVersionBeacon",
-			"A.f8d6e0586b0a20c7.StakingProxy",
+			"A.0000000000000003.FlowToken",
+			"A.0000000000000002.FungibleToken",
+			"A.0000000000000004.FlowFees",
+			"A.0000000000000001.FlowStorageFees",
+			"A.0000000000000001.FlowServiceAccount",
+			"A.0000000000000001.FlowClusterQC",
+			"A.0000000000000001.FlowDKG",
+			"A.0000000000000001.FlowEpoch",
+			"A.0000000000000001.FlowIDTableStaking",
+			"A.0000000000000001.FlowStakingCollection",
+			"A.0000000000000001.LockedTokens",
+			"A.0000000000000001.NodeVersionBeacon",
+			"A.0000000000000001.StakingProxy",
 			"s.7465737400000000000000000000000000000000000000000000000000000000",
 			"I.Crypto",
 			"I.Test",
-			"A.f8d6e0586b0a20c7.ExampleNFT",
-			"A.f8d6e0586b0a20c7.NFTStorefrontV2",
-			"A.f8d6e0586b0a20c7.NFTStorefront",
+			"A.0000000000000001.ExampleNFT",
+			"A.0000000000000001.NFTStorefrontV2",
+			"A.0000000000000001.NFTStorefront",
 		},
 		coverageReport.ExcludedLocationIDs(),
 	)
@@ -3889,6 +3889,7 @@ func TestGetEventsFromIntegrationTests(t *testing.T) {
 
 	const testCode = `
         import Test
+        import FooContract from 0x0000000000000005
 
         pub let blockchain = Test.newEmulatorBlockchain()
         pub let account = blockchain.createAccount()
@@ -3916,7 +3917,7 @@ func TestGetEventsFromIntegrationTests(t *testing.T) {
             Test.expect(result, Test.beSucceeded())
             Test.assert(result.returnValue! as! Bool)
 
-            let typ = CompositeType("A.01cf0e2f2f715450.FooContract.ContractInitialized")!
+            let typ = Type<FooContract.ContractInitialized>()
             let events = blockchain.eventsOfType(typ)
             Test.assertEqual(1, events.length)
         }
@@ -3933,9 +3934,13 @@ func TestGetEventsFromIntegrationTests(t *testing.T) {
             let result = blockchain.executeTransaction(tx)
             Test.expect(result, Test.beSucceeded())
 
-            let typ = CompositeType("A.01cf0e2f2f715450.FooContract.NumberAdded")!
+            let typ = Type<FooContract.NumberAdded>()
             let events = blockchain.eventsOfType(typ)
             Test.assertEqual(1, events.length)
+
+            let event = events[0] as! FooContract.NumberAdded
+            Test.assertEqual(78557, event.n)
+            Test.assertEqual("Sierpinski", event.trait)
 
             let evts = blockchain.events()
             Test.expect(evts.length, Test.beGreaterThan(1))
@@ -4420,7 +4425,7 @@ func TestReferenceDeployedContractTypes(t *testing.T) {
 
 		const testCode = `
             import Test
-            import FooContract from 0x01cf0e2f2f715450
+            import FooContract from 0x0000000000000005
 
             pub let blockchain = Test.newEmulatorBlockchain()
             pub let account = blockchain.createAccount()
@@ -4543,7 +4548,7 @@ func TestReferenceDeployedContractTypes(t *testing.T) {
 
 		const testCode = `
             import Test
-            import FooContract from 0x01cf0e2f2f715450
+            import FooContract from 0x0000000000000005
 
             pub let blockchain = Test.newEmulatorBlockchain()
             pub let account = blockchain.createAccount()

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -74,23 +74,23 @@ type Result struct {
 	Error    error
 }
 
-// LogCollectionHook can be attached to zerolog.Logger objects, in order
+// logCollectionHook can be attached to zerolog.Logger objects, in order
 // to aggregate the log messages in a string slice, containing only the
 // string message.
-type LogCollectionHook struct {
+type logCollectionHook struct {
 	Logs []string
 }
 
-var _ zerolog.Hook = &LogCollectionHook{}
+var _ zerolog.Hook = &logCollectionHook{}
 
-// NewLogCollectionHook initializes and returns a *LogCollectionHook
-func NewLogCollectionHook() *LogCollectionHook {
-	return &LogCollectionHook{
+// newLogCollectionHook initializes and returns a *LogCollectionHook
+func newLogCollectionHook() *logCollectionHook {
+	return &logCollectionHook{
 		Logs: make([]string, 0),
 	}
 }
 
-func (h *LogCollectionHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
+func (h *logCollectionHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
 	if level != zerolog.NoLevel {
 		logMsg := strings.Replace(
 			msg,
@@ -144,7 +144,7 @@ type TestRunner struct {
 	// logCollection is a hook attached in the program logger of
 	// the script environment, in order to aggregate and expose
 	// log messages from test cases and contracts.
-	logCollection *LogCollectionHook
+	logCollection *logCollectionHook
 
 	// randomSeed is used for randomized test case execution.
 	randomSeed int64
@@ -155,7 +155,7 @@ type TestRunner struct {
 }
 
 func NewTestRunner() *TestRunner {
-	logCollectionHook := NewLogCollectionHook()
+	logCollectionHook := newLogCollectionHook()
 	output := zerolog.ConsoleWriter{Out: os.Stdout}
 	output.FormatMessage = func(i interface{}) string {
 		msg := i.(string)
@@ -169,8 +169,8 @@ func NewTestRunner() *TestRunner {
 	logger := zerolog.New(output).With().Timestamp().Logger().Hook(logCollectionHook)
 	blockchain, err := emulator.New(
 		emulator.WithStorageLimitEnabled(false),
-		emulator.Contracts(CommonContracts),
-		emulator.WithChainID(Chain.ChainID()),
+		emulator.Contracts(commonContracts),
+		emulator.WithChainID(chain.ChainID()),
 	)
 	if err != nil {
 		panic(err)
@@ -580,7 +580,7 @@ func (r *TestRunner) interpreterContractValueHandler(
 
 		default:
 			if _, ok := compositeType.Location.(common.AddressLocation); ok {
-				invocation, found := ContractInvocations[compositeType.Identifier]
+				invocation, found := contractInvocations[compositeType.Identifier]
 				if !found {
 					panic(fmt.Errorf("contract invocation not found"))
 				}

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -169,7 +169,8 @@ func NewTestRunner() *TestRunner {
 	logger := zerolog.New(output).With().Timestamp().Logger().Hook(logCollectionHook)
 	blockchain, err := emulator.New(
 		emulator.WithStorageLimitEnabled(false),
-		emulator.Contracts(emulator.CommonContracts),
+		emulator.Contracts(CommonContracts),
+		emulator.WithChainID(Chain.ChainID()),
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
## Description

Below is a working example of utilizing types from deployed contracts, inside of a test script:

```cadence
import Test
// The address `0x0000000000000005` comes from the account created in the lines below.
// This is where the `FooContract` is also deployed in the `setup()` function.
// However, we can't avoid the chicken-and-egg problem, developers will have to probably
// log the account to get the address, which will be sequential and guaranteed to be the same.
// import FooContract from account.address is not possible.
import FooContract from 0x0000000000000005

pub let blockchain = Test.newEmulatorBlockchain()
pub let account = blockchain.createAccount()

pub fun setup() {
    let contractCode = Test.readFile("../contracts/FooContract.cdc")
    let err = blockchain.deployContract(
        name: "FooContract",
        code: contractCode,
        account: account,
        arguments: []
    )

    Test.expect(err, Test.beNil())

    blockchain.useConfiguration(Test.Configuration({
        "../contracts/FooContract.cdc": account.address
    }))
}

pub fun testGetSpecialNumber() {
    let script = Test.readFile("../scripts/get_special_number.cdc")
    let result = blockchain.executeScript(script, [])

    Test.expect(result, Test.beSucceeded())

    // Type-cast from `AnyStruct` to the `SpecialNumber` type defined on `FooContract` contract
    let specialNumbers = result.returnValue! as! [FooContract.SpecialNumber]
    let specialNumber = specialNumbers[0]

    // We can even create an instance of the `SpecialNumber` type, and use it in assertions
    let expected = FooContract.SpecialNumber(n: 1729, trait: "Harshad")
    Test.assertEqual(expected, specialNumber)
}

pub fun testAddSpecialNumber() {
    let code = Test.readFile("../transactions/add_special_number.cdc")
    let tx = Test.Transaction(
        code: code,
        authorizers: [account.address],
        signers: [account],
        arguments: [78557, "Sierpinski"]
    )

    let result = blockchain.executeTransaction(tx)
    Test.expect(result, Test.beSucceeded())

    // No need to construct `CompositeType` for filtering blockchain events
    let typ = Type<FooContract.NumberAdded>()
    let events = blockchain.eventsOfType(typ)
    Test.assertEqual(1, events.length)

    // We can even type-cast events from `AnyStruct` to their actual type, and use
    // this object to perform assertions on the event payload.
    let event = events[0] as! FooContract.NumberAdded
    Test.assertEqual(78557, event.n)
    Test.assertEqual("Sierpinski", event.trait)
}
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
