### PR TITLE
Run CI separately for each sub-module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,10 @@ on:
       - 'v**'
 
 jobs:
-  test:
-    name: Test
+  test-test:
+    name: Test (Test Framework)
     runs-on: ubuntu-20.04
     steps:
-    - name: Install dependencies
-      run: sudo apt-get update && sudo apt-get install wabt
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
@@ -35,9 +33,79 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Test
-      run: make
+      run: make test-test
     - name: Check tidy
-      run: make check-tidy
+      run: make check-tidy-test
+
+  test-lint:
+    name: Test (Lint)
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.19.x'
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Test
+        run: make test-lint
+      - name: Check tidy
+        run: make check-tidy-lint
+
+  test-languageserver:
+    name: Test (Language Server)
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install wabt
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.19.x'
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '15'
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Test
+        run: make test-languageserver
+      - name: Check tidy
+        run: make check-tidy-languageserver
+
+  test-docgen:
+    name: Test (Docgen)
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install wabt
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.19.x'
+      - uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Test
+        run: make test-docgen
+      - name: Check tidy
+        run: make check-tidy-docgen
 
   lint:
     name: Lint

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,39 @@
 .PHONY: test
-test:
-	(cd ./lint && make test && cd -)
+test: test-test test-lint test-languageserver test-docgen
+
+.PHONY: test-test
+test-test:
 	(cd ./test && make test && cd -)
+
+.PHONY: test-lint
+test-lint:
+	(cd ./lint && make test && cd -)
+
+.PHONY: test-languageserver
+test-languageserver:
 	(cd ./languageserver && make test && cd -)
+
+.PHONY: test-docgen
+test-docgen:
 	(cd ./docgen && make test && cd -)
 
 .PHONY: generate
-generate:
+generate: generate-lint generate-test generate-languageserver generate-docgen
+
+.PHONY: generate-lint
+generate-lint:
 	(cd ./lint && make generate && cd -)
+
+.PHONY: generate-test
+generate-test:
 	(cd ./test && make generate && cd -)
+
+.PHONY: generate-languageserver
+generate-languageserver:
 	(cd ./languageserver && make generate && cd -)
+
+.PHONY: generate-docgen
+generate-docgen:
 	(cd ./docgen && make generate && cd -)
 
 .PHONY: check-headers
@@ -20,8 +44,20 @@ check-headers:
 	(cd ./docgen && make check-headers && cd -)
 
 .PHONY: check-tidy
-check-tidy: generate
+check-tidy: check-tidy-lint check-tidy-test check-tidy-languageserver check-tidy-docgen
+
+.PHONY: check-tidy-lint
+check-tidy-lint: generate-lint
 	(cd ./lint && make check-tidy && cd -)
+
+.PHONY: check-tidy-test
+check-tidy-test: generate-test
 	(cd ./test && make check-tidy && cd -)
+
+.PHONY: check-tidy-languageserver
+check-tidy-languageserver: generate-languageserver
 	(cd ./languageserver && make check-tidy && cd -)
+
+.PHONY: check-tidy-docgen
+check-tidy-docgen: generate-docgen
 	(cd ./docgen && make check-tidy && cd -)


### PR DESCRIPTION
## Description

Run CI separately for each sub-module, so that test-failures can be analyzed separately. Also avoid skipping modules if there were test failure in one module.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
