### PR TITLE
[lint] Update cadence version to v0.41.0-stable-cadence.1

### DIFF
--- a/lint/go.mod
+++ b/lint/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v0.39.13-stable-cadence.0.20230815215130-fc15617946a1
-	github.com/onflow/flow-go-sdk v0.41.10-0.20230815215544-c3e9ce914aee
+	github.com/onflow/cadence v0.41.0-stable-cadence.1
+	github.com/onflow/flow-go-sdk v0.44.0-stable-cadence.1
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	google.golang.org/grpc v1.56.1

--- a/lint/go.sum
+++ b/lint/go.sum
@@ -49,10 +49,10 @@ github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APP
 github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/onflow/atree v0.6.0 h1:j7nQ2r8npznx4NX39zPpBYHmdy45f4xwoi+dm37Jk7c=
 github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVFi0tc=
-github.com/onflow/cadence v0.39.13-stable-cadence.0.20230815215130-fc15617946a1 h1:ELu6aFiphx4QAQE64EbYidJjc5DQSF087QfJZfamnXY=
-github.com/onflow/cadence v0.39.13-stable-cadence.0.20230815215130-fc15617946a1/go.mod h1:SxT8/IEkS1drFj2ofUEK9S6KyJ5GQbrm0LX4EFCp/7Q=
-github.com/onflow/flow-go-sdk v0.41.10-0.20230815215544-c3e9ce914aee h1:zU78xj/94YNYtf4CLGWogCTPyrR+1h3QTalsU/ZEKDg=
-github.com/onflow/flow-go-sdk v0.41.10-0.20230815215544-c3e9ce914aee/go.mod h1:JdN8uOpLMFaMTCFSoeck78fYPupTsV7ccvyrDM88nQU=
+github.com/onflow/cadence v0.41.0-stable-cadence.1 h1:ATWDm7WaxogV3f99wCEnVcQWZ36FAHya/4dI7ffw2u8=
+github.com/onflow/cadence v0.41.0-stable-cadence.1/go.mod h1:SxT8/IEkS1drFj2ofUEK9S6KyJ5GQbrm0LX4EFCp/7Q=
+github.com/onflow/flow-go-sdk v0.44.0-stable-cadence.1 h1:6WjkZS1S0nYdphBsdZcU48mrLpccgfuCNX06ry4/c8c=
+github.com/onflow/flow-go-sdk v0.44.0-stable-cadence.1/go.mod h1:aWDwdlvZeX0LTR2buq9D+uPytaZ3hvzxEAMPfLhZCm0=
 github.com/onflow/flow-go/crypto v0.24.9 h1:0EQp+kSZYJepMIiSypfJVe7tzsPcb6UXOdOtsTCDhBs=
 github.com/onflow/flow-go/crypto v0.24.9/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230628215638-83439d22e0ce h1:YQKijiQaq8SF1ayNqp3VVcwbBGXSnuHNHq4GQmVGybE=


### PR DESCRIPTION
## Description

Update to
- cadence [v0.41.0-stable-cadence.1](https://github.com/onflow/cadence/releases/tag/v0.41.0-stable-cadence.1)
- flow-go-sdk [v0.44.0-stable-cadence.1](https://github.com/onflow/flow-go-sdk/releases/tag/v0.44.0-stable-cadence.1)

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
