### PR TITLE
[test] Clean state for each emulator backend instance

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v0.40.1-0.20230828191216-1bbc078efdb3
+	github.com/onflow/cadence v0.40.1-0.20230830181337-52549529e96b
 	github.com/onflow/flow-emulator v0.54.0
 	github.com/onflow/flow-go v0.31.1-0.20230901090702-eeeef3a7bd58
 	github.com/onflow/flow-go-sdk v0.41.10

--- a/test/go.sum
+++ b/test/go.sum
@@ -519,8 +519,8 @@ github.com/onflow/atree v0.1.0-beta1.0.20211027184039-559ee654ece9/go.mod h1:+6x
 github.com/onflow/atree v0.6.0 h1:j7nQ2r8npznx4NX39zPpBYHmdy45f4xwoi+dm37Jk7c=
 github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVFi0tc=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.40.1-0.20230828191216-1bbc078efdb3 h1:Ncadvbf2t4IRY1wJpGgTDs7GEpGO5RgT5HmKSifhoaQ=
-github.com/onflow/cadence v0.40.1-0.20230828191216-1bbc078efdb3/go.mod h1:2ggmhENvPPZXRnv9SmqN2xiYvluu4wx/96GCpeRh8lU=
+github.com/onflow/cadence v0.40.1-0.20230830181337-52549529e96b h1:n9/WMBooqLRXERLYMCa/23qrULdyfBvio2OlGTuo/iM=
+github.com/onflow/cadence v0.40.1-0.20230830181337-52549529e96b/go.mod h1:2ggmhENvPPZXRnv9SmqN2xiYvluu4wx/96GCpeRh8lU=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20230703193002-53362441b57d h1:B7PdhdUNkve5MVrekWDuQf84XsGBxNZ/D3x+QQ8XeVs=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20230703193002-53362441b57d/go.mod h1:xAiV/7TKhw863r6iO3CS5RnQ4F+pBY1TxD272BsILlo=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3 h1:X25A1dNajNUtE+KoV76wQ6BR6qI7G65vuuRXxDDqX7E=

--- a/test/test_framework_provider.go
+++ b/test/test_framework_provider.go
@@ -1,0 +1,81 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"strings"
+
+	"github.com/onflow/cadence/runtime"
+	"github.com/onflow/cadence/runtime/stdlib"
+)
+
+var _ stdlib.TestFramework = &TestFrameworkProvider{}
+
+type TestFrameworkProvider struct {
+	// fileResolver is used to resolve local files.
+	fileResolver FileResolver
+
+	stdlibHandler stdlib.StandardLibraryHandler
+
+	coverageReport *runtime.CoverageReport
+}
+
+func (tf *TestFrameworkProvider) ReadFile(path string) (string, error) {
+	// These are the scripts/transactions used by the
+	// BlockchainHelpers file.
+	if strings.HasPrefix(path, helperFilePrefix) {
+		filename := strings.TrimPrefix(path, helperFilePrefix)
+		switch filename {
+		case "mint_flow.cdc":
+			return string(MintFlowTransaction), nil
+		case "get_flow_balance.cdc":
+			return string(GetFlowBalance), nil
+		case "get_current_block_height.cdc":
+			return string(GetCurrentBlockHeight), nil
+		case "burn_flow.cdc":
+			return string(BurnFlow), nil
+		}
+	}
+
+	if tf.fileResolver == nil {
+		return "", FileResolverNotProvidedError{}
+	}
+
+	return tf.fileResolver(path)
+}
+
+func (tf *TestFrameworkProvider) NewEmulatorBackend() stdlib.Blockchain {
+	return NewEmulatorBackend(
+		tf.fileResolver,
+		tf.stdlibHandler,
+		tf.coverageReport,
+	)
+}
+
+func NewTestFrameworkProvider(
+	fileResolver FileResolver,
+	stdlibHandler stdlib.StandardLibraryHandler,
+	coverageReport *runtime.CoverageReport,
+) stdlib.TestFramework {
+	return &TestFrameworkProvider{
+		fileResolver:   fileResolver,
+		stdlibHandler:  stdlibHandler,
+		coverageReport: coverageReport,
+	}
+}

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -438,7 +438,7 @@ func TestImportContract(t *testing.T) {
 		`
 
 		const fooContract = `
-            import BarContract from 0x01
+            import BarContract from "./BarContract"
 
             pub contract FooContract {
                 init() {}

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -4375,113 +4375,231 @@ func TestNewEmulatorBlockchainCleanState(t *testing.T) {
 func TestReferenceDeployedContractTypes(t *testing.T) {
 	t.Parallel()
 
-	const contractCode = `
-        pub contract FooContract {
-            pub let specialNumbers: {Int: String}
+	t.Run("without init params", func(t *testing.T) {
+		t.Parallel()
 
-            pub struct SpecialNumber {
-                pub let n: Int
-                pub let trait: String
-                pub let numbers: {Int: String}
+		const contractCode = `
+            pub contract FooContract {
+                pub let specialNumbers: {Int: String}
 
-                init(n: Int, trait: String) {
-                    self.n = n
-                    self.trait = trait
-                    self.numbers = FooContract.specialNumbers
+                pub struct SpecialNumber {
+                    pub let n: Int
+                    pub let trait: String
+                    pub let numbers: {Int: String}
+
+                    init(n: Int, trait: String) {
+                        self.n = n
+                        self.trait = trait
+                        self.numbers = FooContract.specialNumbers
+                    }
+
+                    pub fun getAllNumbers(): {Int: String} {
+                        return FooContract.specialNumbers
+                    }
                 }
 
-                pub fun getAllNumbers(): {Int: String} {
-                    return FooContract.specialNumbers
+                init() {
+                    self.specialNumbers = {1729: "Harshad"}
+                }
+
+                pub fun getSpecialNumbers(): [SpecialNumber] {
+                    return [
+                        SpecialNumber(n: 1729, trait: "Harshad")
+                    ]
                 }
             }
+		`
 
-            init() {
-                self.specialNumbers = {1729: "Harshad"}
+		const scriptCode = `
+            import FooContract from "../contracts/FooContract.cdc"
+
+            pub fun main(): [FooContract.SpecialNumber] {
+                return FooContract.getSpecialNumbers()
+            }
+		`
+
+		const testCode = `
+            import Test
+            import FooContract from 0x01cf0e2f2f715450
+
+            pub let blockchain = Test.newEmulatorBlockchain()
+            pub let account = blockchain.createAccount()
+
+            pub fun setup() {
+                let contractCode = Test.readFile("../contracts/FooContract.cdc")
+                let err = blockchain.deployContract(
+                    name: "FooContract",
+                    code: contractCode,
+                    account: account,
+                    arguments: []
+                )
+                Test.expect(err, Test.beNil())
+
+                blockchain.useConfiguration(Test.Configuration({
+                    "../contracts/FooContract.cdc": account.address
+                }))
             }
 
-            pub fun getSpecialNumbers(): [SpecialNumber] {
-                return [
-                    SpecialNumber(n: 1729, trait: "Harshad")
-                ]
+            pub fun testGetSpecialNumber() {
+                let script = Test.readFile("../scripts/get_special_number.cdc")
+                let result = blockchain.executeScript(script, [])
+                Test.expect(result, Test.beSucceeded())
+
+                let specialNumbers = result.returnValue! as! [FooContract.SpecialNumber]
+                let specialNumber = specialNumbers[0]
+                let expected = FooContract.SpecialNumber(n: 1729, trait: "Harshad")
+                Test.assertEqual(expected, specialNumber)
+
+                specialNumber.getAllNumbers()
+                Test.assertEqual(1729, specialNumber.n)
+                Test.assertEqual("Harshad", specialNumber.trait)
             }
-        }
-	`
+		`
 
-	const scriptCode = `
-        import FooContract from "../contracts/FooContract.cdc"
-
-        pub fun main(): [FooContract.SpecialNumber] {
-            return FooContract.getSpecialNumbers()
-        }
-	`
-
-	const testCode = `
-        import Test
-        import FooContract from 0x01cf0e2f2f715450
-
-        pub let blockchain = Test.newEmulatorBlockchain()
-        pub let account = blockchain.createAccount()
-
-        pub fun setup() {
-            let contractCode = Test.readFile("../contracts/FooContract.cdc")
-            let err = blockchain.deployContract(
-                name: "FooContract",
-                code: contractCode,
-                account: account,
-                arguments: []
-            )
-            Test.expect(err, Test.beNil())
-
-            blockchain.useConfiguration(Test.Configuration({
-                "../contracts/FooContract.cdc": account.address
-            }))
-        }
-
-        pub fun testGetSpecialNumber() {
-            let script = Test.readFile("../scripts/get_special_number.cdc")
-            let result = blockchain.executeScript(script, [])
-            Test.expect(result, Test.beSucceeded())
-
-            let specialNumbers = result.returnValue! as! [FooContract.SpecialNumber]
-            let specialNumber = specialNumbers[0]
-            let expected = FooContract.SpecialNumber(n: 1729, trait: "Harshad")
-            Test.assertEqual(expected, specialNumber)
-
-            specialNumber.getAllNumbers()
-            Test.assertEqual(1729, specialNumber.n)
-            Test.assertEqual("Harshad", specialNumber.trait)
-        }
-	`
-
-	fileResolver := func(path string) (string, error) {
-		switch path {
-		case "../contracts/FooContract.cdc":
-			return contractCode, nil
-		case "../scripts/get_special_number.cdc":
-			return scriptCode, nil
-		default:
-			return "", fmt.Errorf("cannot find import location: %s", path)
-		}
-	}
-
-	importResolver := func(location common.Location) (string, error) {
-		switch location := location.(type) {
-		case common.AddressLocation:
-			if location.Name == "FooContract" {
+		fileResolver := func(path string) (string, error) {
+			switch path {
+			case "../contracts/FooContract.cdc":
 				return contractCode, nil
+			case "../scripts/get_special_number.cdc":
+				return scriptCode, nil
+			default:
+				return "", fmt.Errorf("cannot find import location: %s", path)
 			}
 		}
 
-		return "", fmt.Errorf("cannot find import location: %s", location.ID())
-	}
+		importResolver := func(location common.Location) (string, error) {
+			switch location := location.(type) {
+			case common.AddressLocation:
+				if location.Name == "FooContract" {
+					return contractCode, nil
+				}
+			}
 
-	runner := NewTestRunner().
-		WithFileResolver(fileResolver).
-		WithImportResolver(importResolver)
+			return "", fmt.Errorf("cannot find import location: %s", location.ID())
+		}
 
-	results, err := runner.RunTests(testCode)
-	require.NoError(t, err)
-	for _, result := range results {
-		require.NoError(t, result.Error)
-	}
+		runner := NewTestRunner().
+			WithFileResolver(fileResolver).
+			WithImportResolver(importResolver)
+
+		results, err := runner.RunTests(testCode)
+		require.NoError(t, err)
+		for _, result := range results {
+			require.NoError(t, result.Error)
+		}
+	})
+
+	t.Run("with init params", func(t *testing.T) {
+		t.Parallel()
+
+		const contractCode = `
+            pub contract FooContract {
+                pub let specialNumbers: {Int: String}
+
+                pub struct SpecialNumber {
+                    pub let n: Int
+                    pub let trait: String
+                    pub let numbers: {Int: String}
+
+                    init(n: Int, trait: String) {
+                        self.n = n
+                        self.trait = trait
+                        self.numbers = FooContract.specialNumbers
+                    }
+
+                    pub fun getAllNumbers(): {Int: String} {
+                        return FooContract.specialNumbers
+                    }
+                }
+
+                init(specialNumbers: {Int: String}) {
+                    self.specialNumbers = specialNumbers
+                }
+
+                pub fun getSpecialNumbers(): [SpecialNumber] {
+                    return [
+                        SpecialNumber(n: 1729, trait: "Harshad")
+                    ]
+                }
+            }
+		`
+
+		const scriptCode = `
+            import FooContract from "../contracts/FooContract.cdc"
+
+            pub fun main(): [FooContract.SpecialNumber] {
+                return FooContract.getSpecialNumbers()
+            }
+		`
+
+		const testCode = `
+            import Test
+            import FooContract from 0x01cf0e2f2f715450
+
+            pub let blockchain = Test.newEmulatorBlockchain()
+            pub let account = blockchain.createAccount()
+
+            pub fun setup() {
+                let contractCode = Test.readFile("../contracts/FooContract.cdc")
+                let err = blockchain.deployContract(
+                    name: "FooContract",
+                    code: contractCode,
+                    account: account,
+                    arguments: [{1729: "Harshad"}]
+                )
+                Test.expect(err, Test.beNil())
+
+                blockchain.useConfiguration(Test.Configuration({
+                    "../contracts/FooContract.cdc": account.address
+                }))
+            }
+
+            pub fun testGetSpecialNumber() {
+                let script = Test.readFile("../scripts/get_special_number.cdc")
+                let result = blockchain.executeScript(script, [])
+                Test.expect(result, Test.beSucceeded())
+
+                let specialNumbers = result.returnValue! as! [FooContract.SpecialNumber]
+                let specialNumber = specialNumbers[0]
+                let expected = FooContract.SpecialNumber(n: 1729, trait: "Harshad")
+                Test.assertEqual(expected, specialNumber)
+
+                specialNumber.getAllNumbers()
+                Test.assertEqual(1729, specialNumber.n)
+                Test.assertEqual("Harshad", specialNumber.trait)
+            }
+		`
+
+		fileResolver := func(path string) (string, error) {
+			switch path {
+			case "../contracts/FooContract.cdc":
+				return contractCode, nil
+			case "../scripts/get_special_number.cdc":
+				return scriptCode, nil
+			default:
+				return "", fmt.Errorf("cannot find import location: %s", path)
+			}
+		}
+
+		importResolver := func(location common.Location) (string, error) {
+			switch location := location.(type) {
+			case common.AddressLocation:
+				if location.Name == "FooContract" {
+					return contractCode, nil
+				}
+			}
+
+			return "", fmt.Errorf("cannot find import location: %s", location.ID())
+		}
+
+		runner := NewTestRunner().
+			WithFileResolver(fileResolver).
+			WithImportResolver(importResolver)
+
+		results, err := runner.RunTests(testCode)
+		require.NoError(t, err)
+		for _, result := range results {
+			require.NoError(t, result.Error)
+		}
+	})
 }

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -3971,24 +3971,20 @@ func TestGetEventsFromIntegrationTests(t *testing.T) {
 		}
 	}
 
-	contracts := map[string][]byte{
-		"FooContract": []byte(contractCode),
-	}
-
 	importResolver := func(location common.Location) (string, error) {
 		switch location := location.(type) {
 		case common.AddressLocation:
-			code := contracts[location.Name]
-			return string(code), nil
+			if location.Name == "FooContract" {
+				return contractCode, nil
+			}
 		}
 
-		return "", nil
+		return "", fmt.Errorf("cannot find import location: %s", location.ID())
 	}
 
 	runner := NewTestRunner().
 		WithFileResolver(fileResolver).
-		WithImportResolver(importResolver).
-		WithContracts(contracts)
+		WithImportResolver(importResolver)
 
 	results, err := runner.RunTests(testCode)
 	require.NoError(t, err)

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -659,7 +659,7 @@ func (r *TestRunner) parseAndCheckImport(
 				flow.Address(addressLocation.Address),
 			)
 			if err != nil {
-				panic(err)
+				return nil, nil, err
 			}
 			code = string(account.Contracts[addressLocation.Name])
 		} else {
@@ -699,14 +699,14 @@ func (r *TestRunner) parseAndCheckImport(
 					flow.Address(addressLoc.Address),
 				)
 				if err != nil {
-					panic(err)
+					return nil, err
 				}
 				code := account.Contracts[addressLoc.Name]
 				program, err := env.ParseAndCheckProgram(
 					code, addressLoc, true,
 				)
 				if err != nil {
-					panic(err)
+					return nil, err
 				}
 
 				return sema.ElaborationImport{

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -573,6 +573,23 @@ func (r *TestRunner) interpreterContractValueHandler(
 			return contract
 
 		default:
+			if _, ok := compositeType.Location.(common.AddressLocation); ok {
+				constructor := constructorGenerator(common.Address{})
+
+				value, err := inter.InvokeFunctionValue(
+					constructor,
+					[]interpreter.Value{},
+					[]sema.Type{},
+					[]sema.Type{},
+					invocationRange,
+				)
+				if err != nil {
+					panic(err)
+				}
+
+				return value.(*interpreter.CompositeValue)
+			}
+
 			// During tests, imported contracts can be constructed using the constructor,
 			// similar to structs. Therefore, generate a constructor function.
 			return constructorGenerator(common.Address{})

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -574,13 +574,20 @@ func (r *TestRunner) interpreterContractValueHandler(
 
 		default:
 			if _, ok := compositeType.Location.(common.AddressLocation); ok {
-				constructor := constructorGenerator(common.Address{})
+				invocation, found := ContractInvocations[compositeType.Identifier]
+				if !found {
+					panic(fmt.Errorf("contract invocation not found"))
+				}
+				parameterTypes := make([]sema.Type, len(compositeType.ConstructorParameters))
+				for i, constructorParameter := range compositeType.ConstructorParameters {
+					parameterTypes[i] = constructorParameter.TypeAnnotation.Type
+				}
 
 				value, err := inter.InvokeFunctionValue(
-					constructor,
-					[]interpreter.Value{},
-					[]sema.Type{},
-					[]sema.Type{},
+					constructorGenerator(common.Address{}),
+					invocation.ConstructorArguments,
+					invocation.ArgumentTypes,
+					parameterTypes,
 					invocationRange,
 				)
 				if err != nil {

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -522,6 +522,11 @@ func contractValueHandler(
 		}
 	}
 
+	// For composite types (e.g. contracts) that are deployed on
+	// EmulatorBackend's blockchain, we have to declare the
+	// define the value declaration as a composite. This is needed
+	// for nested types that are defined in the composite type,
+	// e.g events / structs / resources / enums etc.
 	return stdlib.StandardLibraryValue{
 		Name:           declaration.Identifier.Identifier,
 		Type:           compositeType,

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -152,10 +152,6 @@ type TestRunner struct {
 	// blockchain is mainly used to obtain system-defined
 	// contracts & their exposed types
 	blockchain *emulator.Blockchain
-
-	// contracts is a mapping of contract names to their
-	// source code.
-	contracts map[string][]byte
 }
 
 func NewTestRunner() *TestRunner {
@@ -204,11 +200,6 @@ func (r *TestRunner) WithCoverageReport(coverageReport *runtime.CoverageReport) 
 
 func (r *TestRunner) WithRandomSeed(seed int64) *TestRunner {
 	r.randomSeed = seed
-	return r
-}
-
-func (r *TestRunner) WithContracts(contracts map[string][]byte) *TestRunner {
-	r.contracts = contracts
 	return r
 }
 
@@ -617,8 +608,9 @@ func (r *TestRunner) interpreterImportHandler(ctx runtime.Context) interpreter.I
 				var programCode []byte
 				// User-defined contracts are injected to test runners
 				// via flow-cli
-				if code, ok := r.contracts[addressLocation.Name]; ok {
-					programCode = code
+				code, err := r.importResolver(location)
+				if err == nil {
+					programCode = []byte(code)
 				} else {
 					// System-defined contracts are obtained from
 					// the blockchain.
@@ -650,8 +642,9 @@ func (r *TestRunner) interpreterImportHandler(ctx runtime.Context) interpreter.I
 					var programCode []byte
 					// User-defined contracts are injected to test runners
 					// via flow-cli
-					if code, ok := r.contracts[addressLoc.Name]; ok {
-						programCode = code
+					code, err := r.importResolver(location)
+					if err == nil {
+						programCode = []byte(code)
 					} else {
 						// System-defined contracts are obtained from
 						// the blockchain.


### PR DESCRIPTION
Continuation of https://github.com/onflow/cadence-tools/issues/139

## Description

Move parts of `EmulatorBackend` to `TestFrameworkProvider`.

`EmulatorBackend` now implements `stdlib.Blockchain`, while `TestFrameworkProvider` implements `stdlib.TestFramework`.

This separation allows us to create multiple `EmulatorBackend` instances, with `Test.newEmulatorBlockchain()`, that come with clean state.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
