### PR TITLE
[test] Allow `TestRunner` to execute test cases randomly

### DIFF
--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -4306,3 +4306,42 @@ func TestBlockchainMoveTime(t *testing.T) {
 		require.NoError(t, result.Error)
 	}
 }
+
+func TestRandomizedTestExecution(t *testing.T) {
+	t.Parallel()
+
+	const code = `
+        import Test
+
+        pub fun testCase1() {
+            log("testCase1")
+        }
+
+        pub fun testCase2() {
+            log("testCase2")
+        }
+
+        pub fun testCase3() {
+            log("testCase3")
+        }
+
+        pub fun testCase4() {
+            log("testCase4")
+        }
+	`
+
+	runner := NewTestRunner().WithRandomSeed(1600)
+	results, err := runner.RunTests(code)
+	require.NoError(t, err)
+
+	resultsStr := PrettyPrintResults(results, "test_script.cdc")
+
+	const expected = `Test results: "test_script.cdc"
+- PASS: testCase4
+- PASS: testCase3
+- PASS: testCase1
+- PASS: testCase2
+`
+
+	assert.Equal(t, expected, resultsStr)
+}


### PR DESCRIPTION
## Description

Users can inject a random seed, in order for test cases to be executed randomly. This can help uncover flaky tests and possibly bugs in source code. Given the same random seed, the sequence of test case execution should be the same. This is so that users can debug the cause of flakiness.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
