### PR TITLE
[test] Add blockchain snapshots

### DIFF
--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -692,6 +692,19 @@ func (e *EmulatorBackend) MoveTime(timeDelta int64) {
 	e.CommitBlock()
 }
 
+// Creates a snapshot of the blockchain, at the
+// current ledger state, with the given name.
+func (e *EmulatorBackend) CreateSnapshot(name string) error {
+	return e.blockchain.CreateSnapshot(name)
+}
+
+// Loads a snapshot of the blockchain, with the
+// given name, and updates the current ledger
+// state.
+func (e *EmulatorBackend) LoadSnapshot(name string) error {
+	return e.blockchain.LoadSnapshot(name)
+}
+
 // excludeCommonLocations excludes the common contracts from appearing
 // in the coverage report, as they skew the coverage metrics.
 func excludeCommonLocations(coverageReport *runtime.CoverageReport) {

--- a/test/go.mod
+++ b/test/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v0.40.1-0.20230830181337-52549529e96b
+	github.com/onflow/cadence v0.40.1-0.20230906152939-75f661676745
 	github.com/onflow/flow-emulator v0.54.0
 	github.com/onflow/flow-go v0.31.1-0.20230901090702-eeeef3a7bd58
 	github.com/onflow/flow-go-sdk v0.41.10

--- a/test/go.sum
+++ b/test/go.sum
@@ -519,8 +519,8 @@ github.com/onflow/atree v0.1.0-beta1.0.20211027184039-559ee654ece9/go.mod h1:+6x
 github.com/onflow/atree v0.6.0 h1:j7nQ2r8npznx4NX39zPpBYHmdy45f4xwoi+dm37Jk7c=
 github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVFi0tc=
 github.com/onflow/cadence v0.20.1/go.mod h1:7mzUvPZUIJztIbr9eTvs+fQjWWHTF8veC+yk4ihcNIA=
-github.com/onflow/cadence v0.40.1-0.20230830181337-52549529e96b h1:n9/WMBooqLRXERLYMCa/23qrULdyfBvio2OlGTuo/iM=
-github.com/onflow/cadence v0.40.1-0.20230830181337-52549529e96b/go.mod h1:2ggmhENvPPZXRnv9SmqN2xiYvluu4wx/96GCpeRh8lU=
+github.com/onflow/cadence v0.40.1-0.20230906152939-75f661676745 h1:a0KwLSP0Z5aPgQupEqQfDz1ly7WaEX4MU5yV3drTxNc=
+github.com/onflow/cadence v0.40.1-0.20230906152939-75f661676745/go.mod h1:2ggmhENvPPZXRnv9SmqN2xiYvluu4wx/96GCpeRh8lU=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20230703193002-53362441b57d h1:B7PdhdUNkve5MVrekWDuQf84XsGBxNZ/D3x+QQ8XeVs=
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20230703193002-53362441b57d/go.mod h1:xAiV/7TKhw863r6iO3CS5RnQ4F+pBY1TxD272BsILlo=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3 h1:X25A1dNajNUtE+KoV76wQ6BR6qI7G65vuuRXxDDqX7E=


### PR DESCRIPTION
**Depends on:** https://github.com/onflow/cadence-tools/pull/205

## Description

Allow developers to create snapshots of the blockchain's current ledge state, and load them on demand at any time. For example:

```cadence
import Test
import BlockchainHelpers

pub let blockchain = Test.newEmulatorBlockchain()
pub let helpers = BlockchainHelpers(blockchain: blockchain)

pub fun test() {
    let admin = blockchain.createAccount()
    blockchain.createSnapshot("adminCreated")

    helpers.mintFlow(to: admin, amount: 1000.0)
    blockchain.createSnapshot("adminFunded")

    var balance = helpers.getFlowBalance(for: admin)
    Test.assertEqual(1000.0, balance)

    blockchain.loadSnapshot("adminCreated")
            
    balance = helpers.getFlowBalance(for: admin)
    Test.assertEqual(0.0, balance)

    blockchain.loadSnapshot("adminFunded")
            
    balance = helpers.getFlowBalance(for: admin)
    Test.assertEqual(1000.0, balance)
}
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
