### PR TITLE
Auto update to onflow/flow-emulator v0.56.0

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/onflow/cadence v0.42.0
-	github.com/onflow/flow-emulator v0.54.2-0.20231018165559-cb57f007d44c
+	github.com/onflow/flow-emulator v0.56.0
 	github.com/onflow/flow-go v0.32.2-0.20231017202518-0b275f42906c
 	github.com/onflow/flow-go-sdk v0.41.11
 	github.com/rs/zerolog v1.29.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -546,8 +546,8 @@ github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20230703193002-5
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20230703193002-53362441b57d/go.mod h1:xAiV/7TKhw863r6iO3CS5RnQ4F+pBY1TxD272BsILlo=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3 h1:X25A1dNajNUtE+KoV76wQ6BR6qI7G65vuuRXxDDqX7E=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.2.3/go.mod h1:dqAUVWwg+NlOhsuBHex7bEWmsUjsiExzhe/+t4xNH6A=
-github.com/onflow/flow-emulator v0.54.2-0.20231018165559-cb57f007d44c h1:GLGfVwYLUFUeQuqGMVeSZ6guNGAAnQoglW1bJ6LmFyc=
-github.com/onflow/flow-emulator v0.54.2-0.20231018165559-cb57f007d44c/go.mod h1:luhvLpxcpaHzfa+mqwgRTFLBYASdu7EorGbKkKKB9SI=
+github.com/onflow/flow-emulator v0.56.0 h1:rovvMOd3tbfHYPFft+e4d0EO/fVEvHIYkBdKwxuH73I=
+github.com/onflow/flow-emulator v0.56.0/go.mod h1:luhvLpxcpaHzfa+mqwgRTFLBYASdu7EorGbKkKKB9SI=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.0 h1:XEKE6qJUw3luhsYmIOteXP53gtxNxrwTohgxJXCYqBE=
 github.com/onflow/flow-ft/lib/go/contracts v0.7.0/go.mod h1:kTMFIySzEJJeupk+7EmXs0EJ6CBWY/MV9fv9iYQk+RU=
 github.com/onflow/flow-go v0.32.2-0.20231017202518-0b275f42906c h1:QJGwyt9t6TbRbIAO7+wl7t2OUOfhaaB/9PC9RCxW5lc=


### PR DESCRIPTION
## Description

Automatically update to:
- [onflow/flow-emulator v0.56.0](https://github.com/onflow/flow-emulator/releases/tag/v0.56.0)

