### PR TITLE
[test] Fix storage errors for unit testing

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2
+	github.com/onflow/atree v0.6.0
 	github.com/onflow/cadence v0.42.5
 	github.com/onflow/flow-emulator v0.58.0
 	github.com/onflow/flow-go v0.32.4-0.20231115172515-c1ec969fd6f2
@@ -102,7 +103,6 @@ require (
 	github.com/multiformats/go-multistream v0.4.1 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/onflow/atree v0.6.0 // indirect
 	github.com/onflow/flow-core-contracts/lib/go/contracts v1.2.4-0.20231016154253-a00dbf7c061f // indirect
 	github.com/onflow/flow-core-contracts/lib/go/templates v1.2.4-0.20231016154253-a00dbf7c061f // indirect
 	github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20230711213910-baad011d2b13 // indirect

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -640,10 +640,11 @@ func (r *TestRunner) interpreterContractValueHandler(
 					if err != nil {
 						panic(err)
 					}
-					err = storage.Commit(inter, true)
-					if err != nil {
-						panic(err)
-					}
+				}
+
+				err = storage.Commit(inter, true)
+				if err != nil {
+					panic(err)
 				}
 			}
 


### PR DESCRIPTION
Work towards https://github.com/onflow/developer-grants/issues/216

## Description

In `InterpreterConfig.ContractValueHandler` function, we would override the interpreter's shared state with a new storage based on emulator's ledger.
```go
storage := runtime.NewStorage(
	r.backend.blockchain.NewScriptEnvironment(),
	nil,
)
// Update the storage to reflect the changes
// from deployments in setup() function.
inter.SharedState.Config.Storage = storage
```
This proved to be problematic, as the new storage would not contain the constructed composite values needed for testing, e.g. `I.Test`. Resulting in the following error:
```shell
error: internal error: slab (0x0.7) not found: slab not found for stored value
```
The `slab (0x0.7)` would contain the emulator backend:
```cadence
access(all) contract Test {

    /// backend emulates a real network.
    ///
    access(self) let backend: AnyStruct{BlockchainBackend}

    init(backend: AnyStruct{BlockchainBackend}) {
        self.backend = backend
    }
    ...
}
```
To fix this, we simply store every slab from the new storage, to the current environment's storage.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
