### PR TITLE
[lint] Update to Cadence v0.42.1

### DIFF
--- a/lint/go.mod
+++ b/lint/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v0.42.0
-	github.com/onflow/flow-go-sdk v0.41.11
+	github.com/onflow/cadence v0.42.1
+	github.com/onflow/flow-go-sdk v0.41.12
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15
 	google.golang.org/grpc v1.53.0

--- a/lint/go.sum
+++ b/lint/go.sum
@@ -43,10 +43,10 @@ github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp9
 github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/onflow/atree v0.6.0 h1:j7nQ2r8npznx4NX39zPpBYHmdy45f4xwoi+dm37Jk7c=
 github.com/onflow/atree v0.6.0/go.mod h1:gBHU0M05qCbv9NN0kijLWMgC47gHVNBIp4KmsVFi0tc=
-github.com/onflow/cadence v0.42.0 h1:XatyCy1pZu10x+JouRU6cZ9A50dF3uM+ubqYUER1/Vk=
-github.com/onflow/cadence v0.42.0/go.mod h1:raU8va8QRyTa/eUbhej4mbyW2ETePfSaywoo36MddgE=
-github.com/onflow/flow-go-sdk v0.41.11 h1:x1nS91Tn0M4BZbZNSCMU7Vjgx9yjBJfjWWAIOihxDVk=
-github.com/onflow/flow-go-sdk v0.41.11/go.mod h1:M6wvgjcpfnmaqM+3IgaVgbHWRCmns3sbg3KfYj4+5MM=
+github.com/onflow/cadence v0.42.1 h1:Til0aa+TX2o9CM/0OFUPEssP0BoZBfpFRa4qefRgr0E=
+github.com/onflow/cadence v0.42.1/go.mod h1:raU8va8QRyTa/eUbhej4mbyW2ETePfSaywoo36MddgE=
+github.com/onflow/flow-go-sdk v0.41.12 h1:SrdHxpjqUHSjwToCTtcuvquSmjW9AA/QuwY9aex9f8c=
+github.com/onflow/flow-go-sdk v0.41.12/go.mod h1:WJh4pkajUdLdcwqXqwhd0eLm4wz0cvw1vTgHZo4//NE=
 github.com/onflow/flow-go/crypto v0.24.7 h1:RCLuB83At4z5wkAyUCF7MYEnPoIIOHghJaODuJyEoW0=
 github.com/onflow/flow-go/crypto v0.24.7/go.mod h1:fqCzkIBBMRRkciVrvW21rECKq1oD7Q6u+bCI78lfNX0=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20230602212908-08fc6536d391 h1:6uKg0gpLKpTZKMihrsFR0Gkq++1hykzfR1tQCKuOfw4=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v0.42.1](https://github.com/onflow/cadence/releases/tag/v0.42.1)
- [onflow/flow-go-sdk v0.41.12](https://github.com/onflow/flow-go-sdk/releases/tag/v0.41.12)

