### PR TITLE
[test] Increase the number of predefined accounts to 20

### DIFF
--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -53,7 +53,7 @@ const helperFilePrefix = "\x00helper/"
 
 // The number of predefined accounts that are created
 // upon initialization of EmulatorBackend.
-const initialAccountsNumber = 10
+const initialAccountsNumber = 20
 
 var _ stdlib.Blockchain = &EmulatorBackend{}
 


### PR DESCRIPTION
## Description

After some feedback from community members using the testing framework for their dApps, the number of 10 predefined accounts for contract deployments is rather low. To better simulate the setup of `testnet`/`mainnet`, each contract should be deployed in its own account. To test for fields/methods with access modifier `access(account)`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
