### PR TITLE
[test] Test framework bug fixes

### DIFF
--- a/test/helpers/blockchain_helpers.go
+++ b/test/helpers/blockchain_helpers.go
@@ -69,7 +69,7 @@ func BlockchainHelpersChecker() *sema.Checker {
 
 	checker, err := sema.NewChecker(
 		program,
-		common.IdentifierLocation("BlockchainHelpers"),
+		BlockchainHelpersLocation,
 		nil,
 		&sema.Config{
 			BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {

--- a/test/helpers/blockchain_helpers_test.go
+++ b/test/helpers/blockchain_helpers_test.go
@@ -1,0 +1,33 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlockchainHelpersChecker(t *testing.T) {
+	t.Parallel()
+
+	checker := BlockchainHelpersChecker()
+	err := checker.Check()
+	assert.NoError(t, err)
+}

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/onflow/cadence-tools/test/helpers"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -4759,14 +4757,6 @@ func TestBlockchainReset(t *testing.T) {
 	result, err := runner.RunTest(testCode, "testBlockchainReset")
 	require.NoError(t, err)
 	require.NoError(t, result.Error)
-}
-
-func TestBlockchainHelpersChecker(t *testing.T) {
-	t.Parallel()
-
-	checker := helpers.BlockchainHelpersChecker()
-	err := checker.Check()
-	assert.NoError(t, err)
 }
 
 func TestTestFunctionValidSignature(t *testing.T) {

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -719,34 +719,13 @@ func (r *TestRunner) parseAndCheckImport(
 				return nil, fmt.Errorf("unable to import location: %s", importedLocation)
 			}
 
-			var code []byte
-			if _, found := baseContracts()[addressLoc.Name]; found {
-				// System-defined contracts are obtained from
-				// the blockchain.
-				account, err := r.backend.blockchain.GetAccount(
-					flow.Address(addressLoc.Address),
-				)
-				if err != nil {
-					return nil, err
-				}
-				code = account.Contracts[addressLoc.Name]
-			} else if _, found := r.contracts[addressLoc.Name]; found {
-				contract, err := r.importResolver(addressLoc)
-				if err != nil {
-					return nil, err
-				}
-				code = []byte(contract)
-			}
-
-			program, err := env.ParseAndCheckProgram(
-				code, addressLoc, true,
-			)
+			_, elaboration, err := r.parseAndCheckImport(addressLoc, ctx)
 			if err != nil {
 				return nil, err
 			}
 
 			return sema.ElaborationImport{
-				Elaboration: program.Elaboration,
+				Elaboration: elaboration,
 			}, nil
 		}
 	}

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -706,6 +706,13 @@ func (r *TestRunner) parseAndCheckImport(
 				Elaboration: elaboration,
 			}, nil
 
+		case stdlib.CryptoCheckerLocation:
+			cryptoChecker := stdlib.CryptoChecker()
+			elaboration := cryptoChecker.Elaboration
+			return sema.ElaborationImport{
+				Elaboration: elaboration,
+			}, nil
+
 		default:
 			addressLoc, ok := importedLocation.(common.AddressLocation)
 			if !ok {


### PR DESCRIPTION
## Description

- Minor improvements regarding the `helpers` package
- Fix bug regarding import of built-in `Crypto` contract in other contracts, besides the test file itself
- Simplify the `CheckerConfig.ImportHandler` on `TestRunner.parseAndCheckImport`. This fixes a bug when importing nested contracts, e.g. `A` imports `B` imports `C`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
