### PR TITLE
[LS] Fix WASM regression & add tests

### DIFF
--- a/languageserver/Makefile
+++ b/languageserver/Makefile
@@ -34,7 +34,7 @@ generate:
 	go mod tidy
 
 .PHONY: test
-test: e2e-test generate unit-test
+test: e2e-test generate unit-test wasm-test
 
 .PHONY: unit-test
 unit-test:
@@ -44,6 +44,10 @@ unit-test:
 e2e-test:
 	cd test && npm install && npm t
 	GO111MODULE=on go test -parallel 8 ./...
+
+.PHONY: wasm-test
+wasm-test:
+	cd ../npm-packages/cadence-language-server && npm install && npm run build && npm test
 
 .PHONY: wasm
 wasm:

--- a/languageserver/cmd/languageserver/main_wasm.go
+++ b/languageserver/cmd/languageserver/main_wasm.go
@@ -165,7 +165,7 @@ func start(id int) {
 			return "", fmt.Errorf("CLS %d: getAddressCode not defined", id)
 		}
 
-		res := getAddressCodeFunc.Invoke(location.Address.String())
+		res := getAddressCodeFunc.Invoke(location.String())
 		if res.IsNull() || res.IsUndefined() {
 			return "", fmt.Errorf("CLS %d: getAddressCode failed: %s", id, res)
 		}

--- a/npm-packages/cadence-language-server/package-lock.json
+++ b/npm-packages/cadence-language-server/package-lock.json
@@ -1,22 +1,21 @@
 {
   "name": "@onflow/cadence-language-server",
-  "version": "0.26.1",
+  "version": "0.33.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@onflow/cadence-language-server",
-      "version": "0.26.1",
+      "version": "0.33.2",
       "license": "Apache-2.0",
-      "dependencies": {
-        "vscode-jsonrpc": "^5.0.1"
-      },
       "devDependencies": {
-        "@types/jest": "^26.0.14",
+        "@types/jest": "^26.0.24",
+        "@types/node": "^20.9.0",
         "jest": "^26.5.3",
         "node-fetch": "^2.6.1",
         "ts-jest": "^26.4.1",
-        "typescript": "^4.0.2"
+        "typescript": "^4.0.2",
+        "vscode-languageserver-protocol": "^3.17.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -960,9 +959,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "26.0.23",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
-      "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
+      "version": "26.0.24",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
+      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
       "dev": true,
       "dependencies": {
         "jest-diff": "^26.0.0",
@@ -970,10 +969,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "15.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
-      "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
-      "dev": true
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
+      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -5672,6 +5674,12 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -5813,12 +5821,29 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
-      "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true,
       "engines": {
-        "node": ">=8.0.0 || >=10.0.0"
+        "node": ">=14.0.0"
       }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -6796,9 +6821,9 @@
       }
     },
     "@types/jest": {
-      "version": "26.0.23",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.23.tgz",
-      "integrity": "sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==",
+      "version": "26.0.24",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.24.tgz",
+      "integrity": "sha512-E/X5Vib8BWqZNRlDxj9vYXhsDwPYbPINqKF9BsnSoon4RQ0D9moEuLD8txgyypFLH7J4+Lho9Nr/c8H0Fi+17w==",
       "dev": true,
       "requires": {
         "jest-diff": "^26.0.0",
@@ -6806,10 +6831,13 @@
       }
     },
     "@types/node": {
-      "version": "15.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
-      "integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
-      "dev": true
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
+      "integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -10480,6 +10508,12 @@
       "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
       "dev": true
     },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -10595,9 +10629,26 @@
       }
     },
     "vscode-jsonrpc": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz",
-      "integrity": "sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A=="
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
+      "requires": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/npm-packages/cadence-language-server/package.json
+++ b/npm-packages/cadence-language-server/package.json
@@ -14,14 +14,13 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@types/jest": "^26.0.14",
+    "@types/jest": "^26.0.24",
+    "@types/node": "^20.9.0",
     "jest": "^26.5.3",
     "node-fetch": "^2.6.1",
     "ts-jest": "^26.4.1",
-    "typescript": "^4.0.2"
-  },
-  "dependencies": {
-    "vscode-jsonrpc": "^5.0.1"
+    "typescript": "^4.0.2",
+    "vscode-languageserver-protocol": "^3.17.5"
   },
   "files": [
     "dist/**/*"

--- a/npm-packages/cadence-language-server/src/index.ts
+++ b/npm-packages/cadence-language-server/src/index.ts
@@ -33,6 +33,10 @@ export interface Callbacks {
   // to get the code for an imported address, if any
   getAddressCode?(address: string): string | undefined
 
+  // The function that the language server calls
+  // to get the code for a string import, if any
+  getStringCode?(location: string): string | undefined
+
   // The function that the language client calls
   // to write a message object to the server.
   // The object is an JSON-RPC request/response object
@@ -119,6 +123,14 @@ export class CadenceLanguageServer {
       }
 
       return callbacks.getAddressCode(address)
+    }
+
+    env[this.functionName('getStringCode')] = (location: string): string | undefined => {
+      if (!callbacks.getStringCode) {
+        return undefined
+      }
+
+      return callbacks.getStringCode(location)
     }
 
     env[this.functionName('onServerClose')] = (): void => {

--- a/npm-packages/cadence-language-server/src/index.ts
+++ b/npm-packages/cadence-language-server/src/index.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import {Message} from "vscode-jsonrpc/lib/messages";
+import {Message} from "vscode-languageserver-protocol";
 import {go} from './go.js'
 import WebAssemblyInstantiatedSource = WebAssembly.WebAssemblyInstantiatedSource
 

--- a/npm-packages/cadence-language-server/tests/index.test.ts
+++ b/npm-packages/cadence-language-server/tests/index.test.ts
@@ -1,27 +1,161 @@
 import {CadenceLanguageServer} from "../src"
 import * as fs from "fs"
-import {Message, RequestMessage} from "vscode-jsonrpc/lib/messages"
+import {
+  createProtocolConnection,
+  DidOpenTextDocumentNotification,
+  ExitNotification,
+  InitializeRequest,
+  ProtocolConnection,
+  PublishDiagnosticsNotification,
+  PublishDiagnosticsParams,
+  DataCallback,
+  Disposable,
+  Logger,
+  Message,
+  MessageReader,
+  MessageWriter,
+  PartialMessageInfo,
+  TextDocumentItem,
+} from "vscode-languageserver-protocol"
 import {Callbacks} from "../dist"
 
-test("start", async () => {
-  const binary = fs.readFileSync(require.resolve('../dist/cadence-language-server.wasm'))
-  const messages: Message[] = []
-  let callbacks: Callbacks = {
-    toClient(message: Message) {
-      messages.push(message)
-    },
-    toServer() {
-      fail("toServer was not initialized")
-    }
-  }
+const binary = fs.readFileSync(require.resolve('../dist/cadence-language-server.wasm'))
+async function withConnection(callbacks: Callbacks = {}, callback: (connection: ProtocolConnection) => Promise<void>) {  
+  // Hack to load the wasm module multiple times for testing
+  await (CadenceLanguageServer as any).load(binary)
+
+  // Start the language server
   await CadenceLanguageServer.create(binary, callbacks)
-  const request: RequestMessage = {
-    jsonrpc: '2.0',
-    id: 1,
-    method: 'initialize',
-    params: {}
+
+  const logger: Logger = {
+    error(message: string) {
+      console.error(message);
+    },
+    warn(message: string) {
+      console.warn(message);
+    },
+    info(message: string) {
+      console.info(message);
+    },
+    log(message: string) {
+      console.log(message);
+    },
   };
 
-  callbacks.toServer?.(undefined, request)
-  expect(messages.length).not.toEqual(0)
+  const writer: MessageWriter = {
+    onClose(_: (_: void) => void): Disposable {
+      return Disposable.create(() => {});
+    },
+    onError(_: (error: [Error, Message, number]) => void): Disposable {
+      return Disposable.create(() => {});
+    },
+    async write(msg: Message): Promise<void> {
+      callbacks.toServer?.(null, msg);
+    },
+    end() {},
+    dispose() {
+      callbacks.onClientClose?.();
+    },
+  };
+
+  const reader: MessageReader = {
+    onError(_: (error: Error) => void): Disposable {
+      return Disposable.create(() => {});
+    },
+    onClose(_: (_: void) => void): Disposable {
+      return Disposable.create(() => {});
+    },
+    onPartialMessage(_: (m: PartialMessageInfo) => void): Disposable {
+      return Disposable.create(() => {});
+    },
+    listen(dataCallback: DataCallback): Disposable {
+      callbacks.toClient = (message) => dataCallback(message);
+      return Disposable.create(() => {});
+    },
+    dispose() {
+      console.log(
+        '-------------------------->',
+        'Language Client is closed. Do something!',
+      );
+      callbacks.onClientClose?.();
+    },
+  };
+
+  const connection = createProtocolConnection(reader, writer, logger)
+  connection.listen()
+
+  await connection.sendRequest(InitializeRequest.type,
+    {
+      capabilities: {},
+      processId: process.pid,
+      rootUri: '/',
+      workspaceFolders: null,
+      initializationOptions: {}
+    }
+  )
+
+  try {
+    await callback(connection)
+  } finally {
+    connection.sendNotification(ExitNotification.type)
+  }
+}
+
+async function createTestDocument(connection: ProtocolConnection, code: string): Promise<string> {
+  const uri = "file:///test.cdc"
+
+  await connection.sendNotification(DidOpenTextDocumentNotification.type, {
+    textDocument: TextDocumentItem.create(
+      uri,
+      "cadence",
+      1,
+      code,
+    )
+  })
+
+  return uri
+}
+
+test("string import", async () => {
+  await withConnection({
+    getStringCode(location: string) {
+      if (location === "Test") {
+        return "pub contract Test {}"
+      }
+      return undefined
+    }
+  }, async (connection) => {
+    const uri = await createTestDocument(connection, "import Test from \"Test\"")
+
+    const notificationPromise = new Promise<PublishDiagnosticsParams>((resolve) => {
+      connection.onNotification(PublishDiagnosticsNotification.type, resolve)
+    })
+
+    const notificaiton = await notificationPromise
+
+    expect(notificaiton.uri).toEqual(uri)
+    expect(notificaiton.diagnostics).toEqual([])
+  })
+})
+
+test("address import", async () => {
+  await withConnection({
+    getAddressCode(address: string) {
+      if (address === "0000000000000001.Test") {
+        return "pub contract Test {}"
+      }
+      return undefined
+    }
+  }, async (connection) => {
+    const uri = await createTestDocument(connection, "import Test from 0x01")
+
+    const notificationPromise = new Promise<PublishDiagnosticsParams>((resolve) => {
+      connection.onNotification(PublishDiagnosticsNotification.type, resolve)
+    })
+
+    const notificaiton = await notificationPromise
+
+    expect(notificaiton.uri).toEqual(uri)
+    expect(notificaiton.diagnostics).toEqual([])
+  })
 })


### PR DESCRIPTION
## Description

It appears that in https://github.com/onflow/cadence-tools/pull/228, I inadvertently introduced a regression into the WASM LS & was also missing certain necessary JS changes to the WASM NPM package.

This PR does the following:
 - Fixes regression with only address being used for address identifiers (i.e. "0000000000000001" instead of "0000000000000001.HelloWorld")
 - Adds WASM integration tests into the test CI job & creates tests for each of the import resolvers
 - Adds the missing JS wrapper for the `getStringCode` resolver introduced in https://github.com/onflow/cadence-tools/pull/228

I've also manually tested both import resolvers for the WASM LS package in the Flow Playground manually.

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
