### PR TITLE
Always require signer argument when signing a transaction with the se…

### DIFF
--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -642,8 +642,15 @@ func (e *EmulatorBackend) signTransaction(
 	// Sign transaction with each signer
 	// Note: Following logic is borrowed from the flow-ft.
 
+	serviceKey := e.blockchain.ServiceKey()
+
 	for i := len(signerAccounts) - 1; i >= 0; i-- {
 		signerAccount := signerAccounts[i]
+		if signerAccount.Address == common.Address(serviceKey.Address) {
+			// skip payload signing for service account, since we always
+			// sign the envelope with the service account just below
+			continue
+		}
 
 		publicKey := signerAccount.PublicKey.PublicKey
 		accountKeys := e.accountKeys[signerAccount.Address]
@@ -655,7 +662,6 @@ func (e *EmulatorBackend) signTransaction(
 		}
 	}
 
-	serviceKey := e.blockchain.ServiceKey()
 	serviceSigner, err := serviceKey.Signer()
 	if err != nil {
 		return err

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -3851,7 +3851,7 @@ func TestServiceAccount(t *testing.T) {
                 let tx = Test.Transaction(
                     code: code,
                     authorizers: [account.address],
-                    signers: [],
+                    signers: [account],
                     arguments: [receiver.address, 1500.0]
                 )
 


### PR DESCRIPTION
Closes #263 

## Description

Until now, to execute a transaction with the service account, the `signers` array parameter had to be empty:
```cadence
let account = Test.serviceAccount()
let receiver = Test.createAccount()

let code = Test.readFile("../transactions/transfer_flow_tokens.cdc")
let tx = Test.Transaction(
    code: code,
    authorizers: [account.address],
    signers: [],
    arguments: [receiver.address, 1500.0]
)

let txResult = Test.executeTransaction(tx)
```

However, this special case adds some unnecessary complexity to developers, hence we always require the `signers` array parameter to contain the service account:

```cadence
let account = Test.serviceAccount()
let receiver = Test.createAccount()

let code = Test.readFile("../transactions/transfer_flow_tokens.cdc")
let tx = Test.Transaction(
    code: code,
    authorizers: [account.address],
    signers: [account],
    arguments: [receiver.address, 1500.0]
)

let txResult = Test.executeTransaction(tx)
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
