### PR TITLE
[Test] Add WithLogger to TestRunner and default to zerolog.Nop()

### DIFF
--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -735,7 +735,7 @@ func newBlockchain(
 	hook *logCollectionHook,
 	opts ...emulator.Option,
 ) *emulator.Blockchain {
-	testLogger := zerolog.New(logger).With().Timestamp().
+	testLogger := logger.With().Timestamp().
 		Logger().Hook(hook).Level(zerolog.InfoLevel)
 
 	b, err := emulator.New(

--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -149,7 +149,6 @@ var systemContracts = func() []common.AddressLocation {
 
 func NewEmulatorBackend(
 	logger zerolog.Logger,
-	fileResolver FileResolver,
 	stdlibHandler stdlib.StandardLibraryHandler,
 	coverageReport *runtime.CoverageReport,
 ) *EmulatorBackend {

--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -149,6 +148,8 @@ var systemContracts = func() []common.AddressLocation {
 }()
 
 func NewEmulatorBackend(
+	logger zerolog.Logger,
+	fileResolver FileResolver,
 	stdlibHandler stdlib.StandardLibraryHandler,
 	coverageReport *runtime.CoverageReport,
 ) *EmulatorBackend {
@@ -157,11 +158,13 @@ func NewEmulatorBackend(
 	if coverageReport != nil {
 		excludeCommonLocations(coverageReport)
 		blockchain = newBlockchain(
+			logger,
 			logCollectionHook,
 			emulator.WithCoverageReport(coverageReport),
 		)
 	} else {
 		blockchain = newBlockchain(
+			logger,
 			logCollectionHook,
 		)
 	}
@@ -729,18 +732,18 @@ func (e *EmulatorBackend) replaceImports(code string) string {
 
 // newBlockchain returns an emulator blockchain for testing.
 func newBlockchain(
+	logger zerolog.Logger,
 	hook *logCollectionHook,
 	opts ...emulator.Option,
 ) *emulator.Blockchain {
-	output := zerolog.ConsoleWriter{Out: os.Stdout}
-	logger := zerolog.New(output).With().Timestamp().
+	testLogger := zerolog.New(logger).With().Timestamp().
 		Logger().Hook(hook).Level(zerolog.InfoLevel)
 
 	b, err := emulator.New(
 		append(
 			[]emulator.Option{
 				emulator.WithStorageLimitEnabled(false),
-				emulator.WithServerLogger(logger),
+				emulator.WithServerLogger(testLogger),
 				emulator.Contracts(commonContracts),
 				emulator.WithChainID(chain.ChainID()),
 			},

--- a/test/test_framework_provider.go
+++ b/test/test_framework_provider.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/onflow/cadence/runtime"
 	"github.com/onflow/cadence/runtime/stdlib"
+	"github.com/rs/zerolog"
 )
 
 var _ stdlib.TestFramework = &TestFrameworkProvider{}
@@ -67,6 +68,7 @@ func (tf *TestFrameworkProvider) EmulatorBackend() stdlib.Blockchain {
 }
 
 func NewTestFrameworkProvider(
+	logger zerolog.Logger,
 	fileResolver FileResolver,
 	stdlibHandler stdlib.StandardLibraryHandler,
 	coverageReport *runtime.CoverageReport,
@@ -76,6 +78,8 @@ func NewTestFrameworkProvider(
 		stdlibHandler:  stdlibHandler,
 		coverageReport: coverageReport,
 		emulatorBackend: NewEmulatorBackend(
+			logger,
+			fileResolver,
 			stdlibHandler,
 			coverageReport,
 		),

--- a/test/test_framework_provider.go
+++ b/test/test_framework_provider.go
@@ -79,7 +79,6 @@ func NewTestFrameworkProvider(
 		coverageReport: coverageReport,
 		emulatorBackend: NewEmulatorBackend(
 			logger,
-			fileResolver,
 			stdlibHandler,
 			coverageReport,
 		),

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -4831,8 +4831,6 @@ func TestWithLogger(t *testing.T) {
 	t.Parallel()
 
 	const code = `
-    import Test
-
     access(all) fun testWithLogger() {
         log("Hello, world!")
     }

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -4833,7 +4833,7 @@ func TestWithLogger(t *testing.T) {
 	const code = `
 				import Test
 
-				pub fun testWithLogger() {
+				access(all) fun testWithLogger() {
 						log("Hello, world!")
 				}
 	`

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -4847,7 +4847,7 @@ func TestWithLogger(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, result.Error)
 
-	expectedPattern := `{"level":"info","time":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2}Z?","message":"\\u001b\[1;34mLOG:\\u001b\[0m \\"Hello, world!\\""}`
+	expectedPattern := `{"level":"info","time":"[0-9TZ:.-]+","message":"\\u001b\[1;34mLOG:\\u001b\[0m \\"Hello, world!\\""}`
 	assert.Regexp(t, expectedPattern, buf.String())
 }
 

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -4831,11 +4831,11 @@ func TestWithLogger(t *testing.T) {
 	t.Parallel()
 
 	const code = `
-				import Test
+    import Test
 
-				access(all) fun testWithLogger() {
-						log("Hello, world!")
-				}
+    access(all) fun testWithLogger() {
+        log("Hello, world!")
+    }
 	`
 
 	var buf bytes.Buffer
@@ -4847,7 +4847,7 @@ func TestWithLogger(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, result.Error)
 
-	expectedPattern := `{"message":"{\\"level\\":\\"info\\",\\"time\\":\\"[0-9TZ:.-]+\\",\\"message\\":\\"\\\\u001b\[1;34mLOG:\\\\u001b\[0m \\\\\\\"Hello, world!\\\\\\\"\\"}"}`
+	expectedPattern := `{"level":"info","time":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2}","message":"\\u001b\[1;34mLOG:\\u001b\[0m \\"Hello, world!\\""}`
 	assert.Regexp(t, expectedPattern, buf.String())
 }
 

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -3556,7 +3556,7 @@ func TestReplacingImports(t *testing.T) {
 func TestReplaceImports(t *testing.T) {
 	t.Parallel()
 
-	emulatorBackend := NewEmulatorBackend(zerolog.Nop(), nil, nil, nil)
+	emulatorBackend := NewEmulatorBackend(zerolog.Nop(), nil, nil)
 	emulatorBackend.contracts = map[string]common.Address{
 		"C1": {0, 0, 0, 0, 0, 0, 0, 1},
 		"C2": {0, 0, 0, 0, 0, 0, 0, 2},
@@ -3801,7 +3801,7 @@ func TestServiceAccount(t *testing.T) {
 	t.Run("retrieve from EmulatorBackend", func(t *testing.T) {
 		t.Parallel()
 
-		emulatorBackend := NewEmulatorBackend(zerolog.Nop(), nil, nil, nil)
+		emulatorBackend := NewEmulatorBackend(zerolog.Nop(), nil, nil)
 
 		serviceAccount, err := emulatorBackend.ServiceAccount()
 

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -4847,7 +4847,7 @@ func TestWithLogger(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, result.Error)
 
-	expectedPattern := `{"level":"info","time":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2}","message":"\\u001b\[1;34mLOG:\\u001b\[0m \\"Hello, world!\\""}`
+	expectedPattern := `{"level":"info","time":"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-\d{2}:\d{2}Z?","message":"\\u001b\[1;34mLOG:\\u001b\[0m \\"Hello, world!\\""}`
 	assert.Regexp(t, expectedPattern, buf.String())
 }
 

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -121,6 +121,7 @@ type FileResolver func(path string) (string, error)
 
 // TestRunner runs tests.
 type TestRunner struct {
+	logger zerolog.Logger
 
 	// importResolver is used to resolve imports of the *test script*.
 	// Note: This doesn't resolve the imports for the code that is being tested.
@@ -147,8 +148,14 @@ type TestRunner struct {
 
 func NewTestRunner() *TestRunner {
 	return &TestRunner{
+		logger: zerolog.Nop(),
 		contracts: baseContracts(),
 	}
+}
+
+func (r *TestRunner) WithLogger(logger zerolog.Logger) *TestRunner {
+	r.logger = logger
+	return r
 }
 
 func (r *TestRunner) WithImportResolver(importResolver ImportResolver) *TestRunner {
@@ -454,6 +461,7 @@ func (r *TestRunner) initializeEnvironment() (
 	r.testRuntime = runtime.NewInterpreterRuntime(config)
 
 	r.testFramework = NewTestFrameworkProvider(
+		r.logger,
 		r.fileResolver,
 		env,
 		r.coverageReport,


### PR DESCRIPTION
Closes #269 

## Description

Adds a `WithLogger` option to the test runner and defaults to suppressed logs if none is provided (could also output to stdio if preferred, but emulator uses the suppress-if-not-provided pattern already so it felt intuitive to follow this).

I noticed that `master` is now on stable-cadence -- not exactly sure which branch I should be targeting to get these changes into pre-cadence-1.0 release (cc @turbolent)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
