### PR TITLE
[test] Use filenames instead of script ID when printing test results

### DIFF
--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -2164,20 +2164,20 @@ func TestPrettyPrintTestResults(t *testing.T) {
 	results, err := runner.RunTests(code)
 	require.NoError(t, err)
 
-	resultsStr := PrettyPrintResults(results, "test_script.cdc")
+	resultsStr := PrettyPrintResults(results, "tests/test_script.cdc")
 
-	const expected = `Test results: "test_script.cdc"
+	const expected = `Test results: "tests/test_script.cdc"
 - PASS: testFunc1
 - FAIL: testFunc2
 		Execution failed:
 			error: assertion failed: unexpected error occurred
-			 --> 7465737400000000000000000000000000000000000000000000000000000000:9:12
+			 --> tests/test_script.cdc:9:12
 			
 - PASS: testFunc3
 - FAIL: testFunc4
 		Execution failed:
 			error: panic: runtime error
-			  --> 7465737400000000000000000000000000000000000000000000000000000000:17:12
+			  --> tests/test_script.cdc:17:12
 			
 `
 
@@ -4831,9 +4831,10 @@ func TestWithLogger(t *testing.T) {
 	t.Parallel()
 
 	const code = `
-    access(all) fun testWithLogger() {
-        log("Hello, world!")
-    }
+        access(all)
+        fun testWithLogger() {
+            log("Hello, world!")
+        }
 	`
 
 	var buf bytes.Buffer
@@ -4845,8 +4846,8 @@ func TestWithLogger(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, result.Error)
 
-	expectedPattern := `{"level":"info","time":"[0-9TZ:.-]+","message":"\\u001b\[1;34mLOG:\\u001b\[0m \\"Hello, world!\\""}`
-	assert.Regexp(t, expectedPattern, buf.String())
+	assert.Contains(t, buf.String(), "Hello, world!")
+	assert.Equal(t, []string{"Hello, world!"}, runner.Logs())
 }
 
 func TestGetEventsFromIntegrationTests(t *testing.T) {

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -148,7 +148,7 @@ type TestRunner struct {
 
 func NewTestRunner() *TestRunner {
 	return &TestRunner{
-		logger: zerolog.Nop(),
+		logger:    zerolog.Nop(),
 		contracts: baseContracts(),
 	}
 }
@@ -821,19 +821,28 @@ func PrettyPrintResults(results Results, scriptPath string) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "Test results: %q\n", scriptPath)
 	for _, result := range results {
-		sb.WriteString(PrettyPrintResult(result.TestName, result.Error))
+		sb.WriteString(PrettyPrintResult(scriptPath, result.TestName, result.Error))
 		sb.WriteRune('\n')
 	}
 	return sb.String()
 }
 
-func PrettyPrintResult(funcName string, err error) string {
+func PrettyPrintResult(scriptPath, funcName string, err error) string {
 	if err == nil {
 		return fmt.Sprintf("- PASS: %s", funcName)
 	}
 
+	interErr := err.(interpreter.Error)
+
+	// Replace script ID with actual file path
+	errString := strings.ReplaceAll(
+		err.Error(),
+		interErr.Location.String(),
+		scriptPath,
+	)
+
 	// Indent the error messages
-	errString := strings.ReplaceAll(err.Error(), "\n", "\n\t\t\t")
+	errString = strings.ReplaceAll(errString, "\n", "\n\t\t\t")
 
 	return fmt.Sprintf("- FAIL: %s\n\t\t%s", funcName, errString)
 }


### PR DESCRIPTION
Closes https://github.com/onflow/cadence-tools/issues/254

## Description

When printing the test results, it is difficult to guess from which test file the failures come from, e.g.

```shell
error: panic: runtime error
--> 7465737400000000000000000000000000000000000000000000000000000000:9:12
```

vs

```shell
error: panic: runtime error
--> tests/test_script.cdc:9:12
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
