### PR TITLE
[test] Enable `EVM` system contract

### DIFF
--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -133,6 +133,7 @@ var systemContracts = func() []common.AddressLocation {
 		"MetadataViews":              serviceAddress,
 		"ViewResolver":               serviceAddress,
 		"RandomBeaconHistory":        serviceAddress,
+		"EVM":                        serviceAddress,
 	}
 
 	locations := make([]common.AddressLocation, 0)
@@ -741,6 +742,7 @@ func newBlockchain(
 	b, err := emulator.New(
 		append(
 			[]emulator.Option{
+				emulator.WithEVMEnabled(true),
 				emulator.WithStorageLimitEnabled(false),
 				emulator.WithServerLogger(testLogger),
 				emulator.Contracts(commonContracts),


### PR DESCRIPTION
## Description

The Emulator is now initialized with the `emulator.WithEVMEnabled(true)`,  to allow developers to use the `EVM` system contract in their contracts/scripts/transactions.

**NOTE 1:** The `EVM` contract is not yet available for usage in the test script environment, as we need to figure out how to properly setup this environment with the `InternalEVM` type & value (see https://github.com/onflow/flow-go/blob/master/fvm/evm/stdlib/contract.go#L1570-L1581).

**NOTE 1:** By setting `emulator.WithEVMEnabled(true)`, the number of accounts upon bootstrapping changes from **4** to **5**, due to the fact that a new account is created to hold the storage for the `EVM` contract. The side effect of this is that developers have to deploy their contracts to addresses starting from `0x0000000000000006` and above.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
