### PR TITLE
[DG] Fix how to run path

### DIFF
--- a/docgen/README.md
+++ b/docgen/README.md
@@ -11,7 +11,7 @@ Supports generating documentation for following declarations:
 The tool currently supports generating documentation in Markdown format.
 
 ## How To Run
-Navigate to `<cadence_dir>/tools/docgen/cmd` directory and run:
+Navigate to `cadence-tools/docgen/cmd` directory and run:
 ```
 go run main.go <path_to_cadence_file> <output_dir>
 ```


### PR DESCRIPTION
## Description

Path under How To Run section is refering the old struct where the doc-gen tool was under the general cadence repo

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
