### PR TITLE
[lint] Update to Cadence v1.0.0-M6

### DIFF
--- a/lint/go.mod
+++ b/lint/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v1.0.0-M5
-	github.com/onflow/flow-go-sdk v1.0.0-M2
+	github.com/onflow/cadence v1.0.0-M6
+	github.com/onflow/flow-go-sdk v1.0.0-M3
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 	google.golang.org/grpc v1.59.0

--- a/lint/go.sum
+++ b/lint/go.sum
@@ -44,12 +44,12 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f h1:Z8/PgTqOgOg02MTRpTBYO2k16FE6z4wEOtaC2WBR9Xo=
 github.com/onflow/atree v0.6.1-0.20230711151834-86040b30171f/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/cadence v1.0.0-M5 h1:vNG7x2KLLrt2yfVr1HtEXUlUi4GdNo+rkXnPkhSzsFA=
-github.com/onflow/cadence v1.0.0-M5/go.mod h1:a4mccDU90hmuxCLUFzs9J/ANG/rYbFa36h4Z0bBAqNU=
+github.com/onflow/cadence v1.0.0-M6 h1:3Y5xFrmOGMCAaHKNjEwCbnDFlkwZHDzeOtrcX9beWMA=
+github.com/onflow/cadence v1.0.0-M6/go.mod h1:a4mccDU90hmuxCLUFzs9J/ANG/rYbFa36h4Z0bBAqNU=
 github.com/onflow/crypto v0.25.0 h1:BeWbLsh3ZD13Ej+Uky6kg1PL1ZIVBDVX+2MVBNwqddg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
-github.com/onflow/flow-go-sdk v1.0.0-M2 h1:YWeXTo112RF8s6swiOU5oW8JWbOOz392FCeAbGnm+W4=
-github.com/onflow/flow-go-sdk v1.0.0-M2/go.mod h1:mllhNw5WAEug59EWvW3TudcrtPmB5VfLA3iUx7mAA4s=
+github.com/onflow/flow-go-sdk v1.0.0-M3 h1:8ZWn+dmJGoFJ1jTHxS02rVftGwU+2dJkhXpBzvSBWKs=
+github.com/onflow/flow-go-sdk v1.0.0-M3/go.mod h1:MZi3kMUCGDek4Yjlg/g57f2QO3M0tQeDn9GVMFJYReQ=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231121210617-52ee94b830c2 h1:qZjl4wSTG/E9znEjkHF0nNaEdlBLJoOEAtr7xUsTNqc=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231121210617-52ee94b830c2/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-M6](https://github.com/onflow/cadence/releases/tag/v1.0.0-M6)
- [onflow/flow-go-sdk v1.0.0-M3](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-M3)

