### PR TITLE
[lint] Check for nil pointers in CadenceV1Analyzer type annotation inspection

### DIFF
--- a/lint/cadence_v1_analyzer.go
+++ b/lint/cadence_v1_analyzer.go
@@ -283,6 +283,9 @@ func (v *cadenceV1Analyzer) inspectTypeAnnotations(f func(typeAnnotation *ast.Ty
 
 	// Helper function to process a parameter list
 	processParameterList := func(parameterList *ast.ParameterList) {
+		if parameterList == nil {
+			return
+		}
 		for _, parameter := range parameterList.Parameters {
 			processAnnotation(parameter.TypeAnnotation)
 		}
@@ -318,6 +321,9 @@ func (v *cadenceV1Analyzer) inspectTypeAnnotations(f func(typeAnnotation *ast.Ty
 			case *ast.SpecialFunctionDeclaration:
 				processParameterList(declaration.FunctionDeclaration.ParameterList)
 			case *ast.InvocationExpression:
+				if declaration.TypeArguments == nil {
+					return
+				}
 				for _, argument := range declaration.TypeArguments {
 					processAnnotation(argument)
 				}

--- a/lint/cadence_v1_analyzer.go
+++ b/lint/cadence_v1_analyzer.go
@@ -263,9 +263,9 @@ func (v *cadenceV1Analyzer) reportRemovedResourceDestructor(
 
 // Type annotations are not part of traversal, so we need to inspect them separately
 func (v *cadenceV1Analyzer) inspectTypeAnnotations(f func(typeAnnotation *ast.TypeAnnotation)) {
-	// Filter out nil type annotations
 	var processAnnotation func(annotation *ast.TypeAnnotation)
 	processAnnotation = func(annotation *ast.TypeAnnotation) {
+		// Filter out nil type annotations
 		if annotation == nil {
 			return
 		}
@@ -283,6 +283,9 @@ func (v *cadenceV1Analyzer) inspectTypeAnnotations(f func(typeAnnotation *ast.Ty
 
 	// Helper function to process a parameter list
 	processParameterList := func(parameterList *ast.ParameterList) {
+		// Filter out nil parameter lists
+		// This can happen for example in a function declaration with no parameters
+		// (i.e. transaction declaration with no arguments)
 		if parameterList == nil {
 			return
 		}

--- a/lint/cadence_v1_analyzer.go
+++ b/lint/cadence_v1_analyzer.go
@@ -324,9 +324,6 @@ func (v *cadenceV1Analyzer) inspectTypeAnnotations(f func(typeAnnotation *ast.Ty
 			case *ast.SpecialFunctionDeclaration:
 				processParameterList(declaration.FunctionDeclaration.ParameterList)
 			case *ast.InvocationExpression:
-				if declaration.TypeArguments == nil {
-					return
-				}
 				for _, argument := range declaration.TypeArguments {
 					processAnnotation(argument)
 				}

--- a/lint/cadence_v1_analyzer_test.go
+++ b/lint/cadence_v1_analyzer_test.go
@@ -686,4 +686,39 @@ func TestCadenceV1Analyzer(t *testing.T) {
 			diagnostics,
 		)
 	})
+
+	t.Run("no error with empty transaction", func(t *testing.T) {
+		t.Parallel()
+
+		// Ensure that no error is reported/no panic for an empty transaction
+		// I.e. does not throw with an empty function parameter list
+		diagnostics := testAnalyzers(t,
+			`
+			transaction {
+				prepare(signer: &Account) {}
+				execute {}
+			}
+			`,
+			lint.CadenceV1Analyzer,
+		)
+
+		require.Len(t, diagnostics, 0)
+	})
+
+	t.Run("no error when no type annotation", func(t *testing.T) {
+		t.Parallel()
+
+		// Ensure that no error is reported/no panic when there is no type annotation
+		// I.e. does not throw when type for delcaration is inferred
+		diagnostics := testAnalyzers(t,
+			`
+			access(all) fun main() {
+				let foo = 1
+			}
+			`,
+			lint.CadenceV1Analyzer,
+		)
+
+		require.Len(t, diagnostics, 0)
+	})
 }


### PR DESCRIPTION
## Description

Adds missing checks for nil pointer dereferences when traversing type annotations.

Ran into this issue in CI for https://github.com/onflow/cadence-tools/pull/286

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
