### PR TITLE
[lint] Update to Cadence v1.0.0-preview.12

### DIFF
--- a/lint/go.mod
+++ b/lint/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v1.0.0-preview.10
-	github.com/onflow/flow-go-sdk v1.0.0-preview.9
+	github.com/onflow/cadence v1.0.0-preview.12
+	github.com/onflow/flow-go-sdk v1.0.0-preview.10
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 	google.golang.org/grpc v1.59.0

--- a/lint/go.sum
+++ b/lint/go.sum
@@ -44,12 +44,12 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/onflow/atree v0.6.1-0.20240308163425-dc825c20b1a2 h1:jJLDswfAVB0bHCu1y1FPdKukPcTNmN+jYEX9S9phbv0=
 github.com/onflow/atree v0.6.1-0.20240308163425-dc825c20b1a2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/cadence v1.0.0-preview.10 h1:NmsGamBE+wu1ffi6cU59hthmpUvmDDmd378Y9U6JYiE=
-github.com/onflow/cadence v1.0.0-preview.10/go.mod h1:no8+e5V51B9mgfi4U9xdeH+GxcJdoKKDP9gdxEj9Jdg=
+github.com/onflow/cadence v1.0.0-preview.12 h1:1/6vY61ueMqORQAb2rqtjyBw1SCuWh4jM6sKZEn/ANk=
+github.com/onflow/cadence v1.0.0-preview.12/go.mod h1:no8+e5V51B9mgfi4U9xdeH+GxcJdoKKDP9gdxEj9Jdg=
 github.com/onflow/crypto v0.25.0 h1:BeWbLsh3ZD13Ej+Uky6kg1PL1ZIVBDVX+2MVBNwqddg=
 github.com/onflow/crypto v0.25.0/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
-github.com/onflow/flow-go-sdk v1.0.0-preview.9 h1:yQ+JMlsEDnAST30fC5gRWF6afnym5YihqOAlYltlzP4=
-github.com/onflow/flow-go-sdk v1.0.0-preview.9/go.mod h1:fDA92xkyc7qGP4SkhO/Hx98c4H7O0co7+i5mdeqs2jo=
+github.com/onflow/flow-go-sdk v1.0.0-preview.10 h1:7AolYdUBQLCddIfVhD5DoFYUQ+F1xDG8gtzeinqBWcc=
+github.com/onflow/flow-go-sdk v1.0.0-preview.10/go.mod h1:jYAxpaRkLWleW61N5hsvyo8RaLo8WNVvHYg+QtcN1+A=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231121210617-52ee94b830c2 h1:qZjl4wSTG/E9znEjkHF0nNaEdlBLJoOEAtr7xUsTNqc=
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231121210617-52ee94b830c2/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-preview.12](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.12)
- [onflow/flow-go-sdk v1.0.0-preview.10](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.10)

