### PR TITLE
[lint] Remove `[Cadence 1.0]` from Cadence V1 Diagnostics

### DIFF
--- a/lint/cadence_v1_analyzer.go
+++ b/lint/cadence_v1_analyzer.go
@@ -19,8 +19,6 @@
 package lint
 
 import (
-	"fmt"
-
 	"github.com/onflow/cadence/runtime/ast"
 	"github.com/onflow/cadence/runtime/common"
 	"github.com/onflow/cadence/runtime/sema"
@@ -341,7 +339,7 @@ func (v *cadenceV1Analyzer) newDiagnostic(
 	return newDiagnostic(
 		v.program.Location,
 		v.report,
-		fmt.Sprintf("[Cadence 1.0] %s", message),
+		message,
 		ast.NewRangeFromPositioned(nil, position),
 	).WithCode(code).WithURL(docURL).WithCategory(CadenceV1Category)
 }

--- a/lint/cadence_v1_analyzer_test.go
+++ b/lint/cadence_v1_analyzer_test.go
@@ -60,7 +60,7 @@ func TestCadenceV1Analyzer(t *testing.T) {
 				{
 					Location: testLocation,
 					Category: lint.CadenceV1Category,
-					Message:  "[Cadence 1.0] `save` has been replaced by the new Storage API.",
+					Message:  "`save` has been replaced by the new Storage API.",
 					Code:     "C1.0-StorageAPI-Save",
 					URL:      "https://forum.flow.com/t/update-on-cadence-1-0/5197#account-access-got-improved-55",
 					SuggestedFixes: []analysis.SuggestedFix{
@@ -127,7 +127,7 @@ func TestCadenceV1Analyzer(t *testing.T) {
 				{
 					Location:       testLocation,
 					Category:       lint.CadenceV1Category,
-					Message:        "[Cadence 1.0] `linkAccount` has been replaced by the Capability Controller API.",
+					Message:        "`linkAccount` has been replaced by the Capability Controller API.",
 					Code:           "C1.0-StorageAPI-LinkAccount",
 					URL:            "https://forum.flow.com/t/update-on-cadence-1-0/5197#capability-controller-api-replaced-existing-linking-based-capability-api-82",
 					SuggestedFixes: []analysis.SuggestedFix{},
@@ -172,7 +172,7 @@ func TestCadenceV1Analyzer(t *testing.T) {
 				{
 					Location:       testLocation,
 					Category:       lint.CadenceV1Category,
-					Message:        "[Cadence 1.0] `link` has been replaced by the Capability Controller API.",
+					Message:        "`link` has been replaced by the Capability Controller API.",
 					Code:           "C1.0-StorageAPI-Link",
 					URL:            "https://forum.flow.com/t/update-on-cadence-1-0/5197#capability-controller-api-replaced-existing-linking-based-capability-api-82",
 					SuggestedFixes: []analysis.SuggestedFix{},
@@ -217,7 +217,7 @@ func TestCadenceV1Analyzer(t *testing.T) {
 				{
 					Location:       testLocation,
 					Category:       lint.CadenceV1Category,
-					Message:        "[Cadence 1.0] `unlink` has been replaced by the Capability Controller API.",
+					Message:        "`unlink` has been replaced by the Capability Controller API.",
 					Code:           "C1.0-StorageAPI-Unlink",
 					URL:            "https://forum.flow.com/t/update-on-cadence-1-0/5197#capability-controller-api-replaced-existing-linking-based-capability-api-82",
 					SuggestedFixes: []analysis.SuggestedFix{},
@@ -262,7 +262,7 @@ func TestCadenceV1Analyzer(t *testing.T) {
 				{
 					Location: testLocation,
 					Category: lint.CadenceV1Category,
-					Message:  "[Cadence 1.0] `getCapability` has been replaced by the Capability Controller API.",
+					Message:  "`getCapability` has been replaced by the Capability Controller API.",
 					Code:     "C1.0-CapabilityAPI-GetCapability",
 					URL:      "https://forum.flow.com/t/update-on-cadence-1-0/5197#capability-controller-api-replaced-existing-linking-based-capability-api-82",
 					SuggestedFixes: []analysis.SuggestedFix{
@@ -329,7 +329,7 @@ func TestCadenceV1Analyzer(t *testing.T) {
 				{
 					Location:       testLocation,
 					Category:       lint.CadenceV1Category,
-					Message:        "[Cadence 1.0] `getLinkTarget` has been replaced by the Capability Controller API.",
+					Message:        "`getLinkTarget` has been replaced by the Capability Controller API.",
 					Code:           "C1.0-CapabilityAPI-GetLinkTarget",
 					URL:            "https://forum.flow.com/t/update-on-cadence-1-0/5197#capability-controller-api-replaced-existing-linking-based-capability-api-82",
 					SuggestedFixes: []analysis.SuggestedFix{},
@@ -374,7 +374,7 @@ func TestCadenceV1Analyzer(t *testing.T) {
 				{
 					Location:       testLocation,
 					Category:       lint.CadenceV1Category,
-					Message:        "[Cadence 1.0] `addPublicKey` has been removed in favour of the new Key Management API. Please use `keys.add` instead.",
+					Message:        "`addPublicKey` has been removed in favour of the new Key Management API. Please use `keys.add` instead.",
 					Code:           "C1.0-KeyAPI-AddPublicKey",
 					URL:            "https://forum.flow.com/t/update-on-cadence-1-0/5197#capability-controller-api-replaced-existing-linking-based-capability-api-82",
 					SuggestedFixes: []analysis.SuggestedFix{},
@@ -418,7 +418,7 @@ func TestCadenceV1Analyzer(t *testing.T) {
 				{
 					Location: testLocation,
 					Category: lint.CadenceV1Category,
-					Message:  "[Cadence 1.0] `removePublicKey` has been removed in favour of the new Key Management API.\nPlease use `keys.revoke` instead.",
+					Message:  "`removePublicKey` has been removed in favour of the new Key Management API.\nPlease use `keys.revoke` instead.",
 					Code:     "C1.0-KeyAPI-RemovePublicKey",
 					URL:      "https://forum.flow.com/t/update-on-cadence-1-0/5197#deprecated-key-management-api-got-removed-60",
 					SuggestedFixes: []analysis.SuggestedFix{
@@ -514,7 +514,7 @@ func TestCadenceV1Analyzer(t *testing.T) {
 				{
 					Location: testLocation,
 					Category: lint.CadenceV1Category,
-					Message:  "[Cadence 1.0] `destroy` keyword has been removed.  Nested resources will now be implicitly destroyed with their parent.  A `ResourceDestroyed` event can be configured to be emitted to notify clients of the destruction.",
+					Message:  "`destroy` keyword has been removed.  Nested resources will now be implicitly destroyed with their parent.  A `ResourceDestroyed` event can be configured to be emitted to notify clients of the destruction.",
 					Code:     "C1.0-ResourceDestruction",
 					URL:      "https://forum.flow.com/t/update-on-cadence-1-0/5197#force-destruction-of-resources-101",
 					SuggestedFixes: []analysis.SuggestedFix{
@@ -578,7 +578,7 @@ func TestCadenceV1Analyzer(t *testing.T) {
 				{
 					Location: testLocation,
 					Category: lint.CadenceV1Category,
-					Message:  "[Cadence 1.0] `AuthAccount` has been removed in Cadence 1.0.  Please use an authorized `&Account` reference with necessary entitlements instead.",
+					Message:  "`AuthAccount` has been removed in Cadence 1.0.  Please use an authorized `&Account` reference with necessary entitlements instead.",
 					Code:     "C1.0-AuthAccount",
 					URL:      "https://forum.flow.com/t/update-on-cadence-1-0/5197#account-access-got-improved-55",
 					SuggestedFixes: []analysis.SuggestedFix{
@@ -643,7 +643,7 @@ func TestCadenceV1Analyzer(t *testing.T) {
 				{
 					Location: testLocation,
 					Category: lint.CadenceV1Category,
-					Message:  "[Cadence 1.0] `PublicAccount` has been removed in Cadence 1.0.  Please use an `&Account` reference instead.",
+					Message:  "`PublicAccount` has been removed in Cadence 1.0.  Please use an `&Account` reference instead.",
 					Code:     "C1.0-PublicAccount",
 					URL:      "https://forum.flow.com/t/update-on-cadence-1-0/5197#account-access-got-improved-55",
 					SuggestedFixes: []analysis.SuggestedFix{


### PR DESCRIPTION
Closes #314 

## Description

Adding this was an oversight and ends up causing more harm than the value it provides.  IMO we should instead rely on clients to add this information if they need it (based on the category), and adding this only pollutes the diagnostic message.

I'll make a PR to add this messaging to the language server after this is merged

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
