### PR TITLE
[test] Allow contract deployments to service account

### DIFF
--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -614,6 +614,12 @@ func (e *EmulatorBackend) LoadSnapshot(name string) error {
 // Creates the number of predefined accounts that will be used
 // for deploying the contracts under testing.
 func (e *EmulatorBackend) bootstrapAccounts() {
+	serviceAcc, err := e.ServiceAccount()
+	if err != nil {
+		panic(err)
+	}
+	e.accounts[serviceAcc.Address] = serviceAcc
+
 	for i := 0; i < initialAccountsNumber; i++ {
 		_, err := e.CreateAccount()
 		if err != nil {


### PR DESCRIPTION
## Description

As requested from the community, it can be useful sometimes to be able to deploy contracts to the service account.
______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
