### PR TITLE
[test] Add full support for `EVM` contract and core events

### DIFF
--- a/test/core_events/core_events.cdc
+++ b/test/core_events/core_events.cdc
@@ -1,0 +1,31 @@
+access(all)
+contract CoreEvents {
+
+    access(all)
+    event AccountCreated(address: Address)
+
+    access(all)
+    event BlockExecuted(
+        height: UInt64,
+        hash: String,
+        totalSupply: Int,
+        parentHash: String,
+        receiptRoot: String,
+        transactionHashes: [String]
+    )
+
+    access(all)
+    event TransactionExecuted(
+        blockHeight: UInt64,
+        blockHash: String,
+        transactionHash: String,
+        encodedTransaction: String,
+        failed: Bool,
+        vmError: String,
+        transactionType: UInt8,
+        gasConsumed: UInt64,
+        deployedContractAddress: String,
+        returnedValue: String,
+        logs: String
+    )
+}

--- a/test/core_events/core_events.go
+++ b/test/core_events/core_events.go
@@ -1,0 +1,92 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core_events
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/onflow/cadence/runtime/ast"
+	"github.com/onflow/cadence/runtime/common"
+	"github.com/onflow/cadence/runtime/parser"
+	"github.com/onflow/cadence/runtime/sema"
+	"github.com/onflow/cadence/runtime/stdlib"
+)
+
+//go:embed core_events.cdc
+var CoreEvents []byte
+
+const CoreEventsLocation = common.IdentifierLocation("CoreEvents")
+
+func CoreEventsChecker() *sema.Checker {
+	program, err := parser.ParseProgram(
+		nil,
+		CoreEvents,
+		parser.Config{},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	importHandler := func(
+		checker *sema.Checker,
+		importedLocation common.Location,
+		importRange ast.Range,
+	) (sema.Import, error) {
+		var elaboration *sema.Elaboration
+		switch importedLocation {
+		case stdlib.TestContractLocation:
+			testChecker := stdlib.GetTestContractType().Checker
+			elaboration = testChecker.Elaboration
+		default:
+			return nil, fmt.Errorf("import not supported")
+		}
+
+		return sema.ElaborationImport{
+			Elaboration: elaboration,
+		}, nil
+	}
+
+	activation := sema.NewVariableActivation(sema.BaseValueActivation)
+	activation.DeclareValue(stdlib.AssertFunction)
+	activation.DeclareValue(stdlib.PanicFunction)
+
+	checker, err := sema.NewChecker(
+		program,
+		CoreEventsLocation,
+		nil,
+		&sema.Config{
+			BaseValueActivationHandler: func(_ common.Location) *sema.VariableActivation {
+				return activation
+			},
+			AccessCheckMode: sema.AccessCheckModeStrict,
+			ImportHandler:   importHandler,
+		},
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	err = checker.Check()
+	if err != nil {
+		panic(err)
+	}
+
+	return checker
+}

--- a/test/core_events/core_events_test.go
+++ b/test/core_events/core_events_test.go
@@ -1,0 +1,33 @@
+/*
+ * Cadence - The resource-oriented smart contract programming language
+ *
+ * Copyright 2019-2022 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package core_events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCoreEventsChecker(t *testing.T) {
+	t.Parallel()
+
+	checker := CoreEventsChecker()
+	err := checker.Check()
+	assert.NoError(t, err)
+}

--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -537,6 +537,13 @@ func (e *EmulatorBackend) Events(
 		eventTypeString = ""
 	case *interpreter.CompositeStaticType:
 		eventTypeString = eventType.String()
+		if eventTypeString == "I.CoreEvents.CoreEvents.BlockExecuted" {
+			eventTypeString = "evm.BlockExecuted"
+		} else if eventTypeString == "I.CoreEvents.CoreEvents.TransactionExecuted" {
+			eventTypeString = "evm.TransactionExecuted"
+		} else if eventTypeString == "I.CoreEvents.CoreEvents.AccountCreated" {
+			eventTypeString = "flow.AccountCreated"
+		}
 	default:
 		panic(errors.NewUnreachableError())
 	}

--- a/test/go.mod
+++ b/test/go.mod
@@ -192,3 +192,5 @@ require (
 	modernc.org/sqlite v1.28.0 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
+
+replace github.com/onflow/flow-go => ../../flow-go

--- a/test/go.sum
+++ b/test/go.sum
@@ -1827,8 +1827,6 @@ github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240327162334-bd133114f87a 
 github.com/onflow/flow-ft/lib/go/contracts v0.7.1-0.20240327162334-bd133114f87a/go.mod h1:PwsL8fC81cjnUnTfmyL/HOIyHnyaw/JA474Wfj2tl6A=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240327162334-bd133114f87a h1:oe3ErYY8qds7IER/zmNGKT3zz6cFcjC0doX2Q0WOUv0=
 github.com/onflow/flow-ft/lib/go/templates v0.7.1-0.20240327162334-bd133114f87a/go.mod h1:uQ8XFqmMK2jxyBSVrmyuwdWjTEb+6zGjRYotfDJ5pAE=
-github.com/onflow/flow-go v0.34.0-crescendo-preview.8.0.20240328003708-11040f76d0cd h1:QWLgb4okWnmZHN2ebiGUNR1CNdHICE1CxVx7wQY9Q40=
-github.com/onflow/flow-go v0.34.0-crescendo-preview.8.0.20240328003708-11040f76d0cd/go.mod h1:vaUovXWZxbcxCg+wFAvb5SFouo4Q2OI3fj9XwCpbU6M=
 github.com/onflow/flow-go-sdk v1.0.0-M1/go.mod h1:TDW0MNuCs4SvqYRUzkbRnRmHQL1h4X8wURsCw9P9beo=
 github.com/onflow/flow-go-sdk v1.0.0-preview.16 h1:m5Dj5XLUTHIFgjWPDsapaIFKIheBlhFLwZ9aXxwX6hQ=
 github.com/onflow/flow-go-sdk v1.0.0-preview.16/go.mod h1:zQwbb+mHfV7R+xa03xr6RoU13bZOF2uKgdf7dOGELvc=


### PR DESCRIPTION
## Description

- Setup the test environment to allow imports of the `EVM` system contract.
- Introduce a new `CoreEvents` contract, to expose event definition for core Flow & EVM events.

Examples:

```cadence
import Test
import CoreEvents

access(all)
fun test() {
    let account = Test.createAccount()

    let typ = Type<CoreEvents.AccountCreated>()
    let events = Test.eventsOfType(typ)
    Test.expect(events.length, Test.beGreaterThan(1))

    let accountCreatedEvent = events[0] as! CoreEvents.AccountCreated
    Test.assertEqual(
        Address(0x0000000000000006),
        accountCreatedEvent.address
    )
}
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
