### PR TITLE
[test] Properly setup EVM environment to allow usage of EVM types in test scripts

### DIFF
--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -795,7 +795,11 @@ func (r *TestRunner) parseAndCheckImport(
 
 	env.CheckerConfig.ContractValueHandler = contractValueHandler
 
-	err = setupEVMEnvironment(r.backend.blockchain.NewScriptEnvironment(), env)
+	fvmEnv, ok := startCtx.Interface.(environment.Environment)
+	if !ok {
+		panic(fmt.Errorf("failed to retrieve FVM Environment"))
+	}
+	err = setupEVMEnvironment(fvmEnv, env)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Description

Allow importing the `EVM` contract in test scripts, so that developers can reference the types defined in this contract.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
