### PR TITLE
[LS] Restore WASM build on v0.33 branch

### DIFF
--- a/languageserver/Makefile
+++ b/languageserver/Makefile
@@ -25,7 +25,7 @@ PATH := $(PATH):$(GOPATH)/bin
 .PHONY: build
 build:
 	go build -o ./cmd/languageserver/languageserver ./cmd/languageserver
-	# TODO: GOARCH=wasm GOOS=js go build -o ./cmd/languageserver/languageserver.wasm ./cmd/languageserver
+	GOARCH=wasm GOOS=js go build -o ./cmd/languageserver/languageserver.wasm -tags no_cgo ./cmd/languageserver
 
 .PHONY: generate
 generate:
@@ -34,7 +34,7 @@ generate:
 	go mod tidy
 
 .PHONY: test
-test: e2e-test generate unit-test # TODO: wasm-test
+test: e2e-test generate unit-test wasm-test
 
 .PHONY: unit-test
 unit-test:

--- a/npm-packages/cadence-language-server/package.json
+++ b/npm-packages/cadence-language-server/package.json
@@ -9,7 +9,7 @@
   },
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc && cd ../../languageserver && GOARCH=wasm GOOS=js go build -o ../npm-packages/cadence-language-server/dist/cadence-language-server.wasm ./cmd/languageserver && cd ../npm-packages/cadence-language-server",
+    "build": "tsc && cd ../../languageserver && GOARCH=wasm GOOS=js go build -o ../npm-packages/cadence-language-server/dist/cadence-language-server.wasm -tags no_cgo ./cmd/languageserver && cd ../npm-packages/cadence-language-server",
     "test": "jest"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
related to #345 

## Description

Since `onflow/crypto` has been updated to v0.25.1, we can restore the WASM build.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
