### PR TITLE
[lint] Update to Cadence v1.0.0-preview.23

### DIFF
--- a/lint/go.mod
+++ b/lint/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v1.0.0-preview.22
-	github.com/onflow/flow-go-sdk v1.0.0-preview.21
+	github.com/onflow/cadence v1.0.0-preview.23
+	github.com/onflow/flow-go-sdk v1.0.0-preview.22
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 	google.golang.org/grpc v1.63.2

--- a/lint/go.sum
+++ b/lint/go.sum
@@ -40,12 +40,12 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/onflow/atree v0.6.1-0.20240416233652-f4568c0c03df h1:9dmE37nSKCV1obdPFtUgjKFH2yUHmfSkULX5h35l8yo=
 github.com/onflow/atree v0.6.1-0.20240416233652-f4568c0c03df/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/cadence v1.0.0-preview.22 h1:0beXEzVmnm+RQhaw0SqzwyofUJ1Ghpot17wdNEV7DTM=
-github.com/onflow/cadence v1.0.0-preview.22/go.mod h1:3UHGl+T7JjK2S8P+FHOjWwBoTYwAimN0QXW/UYb2PjQ=
+github.com/onflow/cadence v1.0.0-preview.23 h1:2YgRu+e3MQRiz4HBwTj1NrT2nY9rD6wiyrM10JLjbWA=
+github.com/onflow/cadence v1.0.0-preview.23/go.mod h1:3UHGl+T7JjK2S8P+FHOjWwBoTYwAimN0QXW/UYb2PjQ=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
-github.com/onflow/flow-go-sdk v1.0.0-preview.21 h1:7MOAVOnHgvF0Xvm+5FjcOKHWqcEOhsXfqK2OkK98iwY=
-github.com/onflow/flow-go-sdk v1.0.0-preview.21/go.mod h1:c5XHJ+a8/DNs6ntpbxyqXX6v+Cmm+yZj/F327O3vrPE=
+github.com/onflow/flow-go-sdk v1.0.0-preview.22 h1:ahHlppdDd4TjHMfnE73SD15AR16KTgbczdhFjGjAtFM=
+github.com/onflow/flow-go-sdk v1.0.0-preview.22/go.mod h1:0hJfpIajLtBvaAUfJAdvWx6WBVp5hS0DJidc0NJLgE4=
 github.com/onflow/flow/protobuf/go/flow v0.4.0 h1:5TGmPwRmnSt7aawgtPGF9ehoGHHir9Cy9LVoAiU9t/E=
 github.com/onflow/flow/protobuf/go/flow v0.4.0/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/go-ethereum v1.13.4 h1:iNO86fm8RbBbhZ87ZulblInqCdHnAQVY8okBrNsTevc=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-preview.23](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.23)
- [onflow/flow-go-sdk v1.0.0-preview.22](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.22)

