### PR TITLE
[languageserver] Update to Cadence v1.0.0-preview.25

### DIFF
--- a/languageserver/go.mod
+++ b/languageserver/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onflow/cadence-tools/lint v1.0.0-preview.16
 	github.com/onflow/cadence-tools/test v1.0.0-preview.15
 	github.com/onflow/flow-go-sdk v1.0.0-preview.25
-	github.com/onflow/flowkit/v2 v2.0.0-stable-cadence-alpha.17
+	github.com/onflow/flowkit/v2 v2.0.0-stable-cadence-alpha.18
 	github.com/sourcegraph/jsonrpc2 v0.1.0
 	github.com/spf13/afero v1.10.0
 	github.com/spf13/pflag v1.0.5

--- a/languageserver/go.sum
+++ b/languageserver/go.sum
@@ -1970,8 +1970,8 @@ github.com/onflow/flow-nft/lib/go/templates v0.0.0-20240429184308-40c3de711140/g
 github.com/onflow/flow/protobuf/go/flow v0.3.2-0.20231121210617-52ee94b830c2/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/flow/protobuf/go/flow v0.4.1-0.20240412170550-911321113030 h1:I+aosSiJny88O4p3nPbCiUcp/UqN6AepvO6uj82bjH0=
 github.com/onflow/flow/protobuf/go/flow v0.4.1-0.20240412170550-911321113030/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
-github.com/onflow/flowkit/v2 v2.0.0-stable-cadence-alpha.17 h1:cwu+Z8xkZpZgqLco8SAhi97GgFVwD3C3oI7+A4rPsJQ=
-github.com/onflow/flowkit/v2 v2.0.0-stable-cadence-alpha.17/go.mod h1:TOdtmA3UjbWY+BJSNdTYyXQ+dstjSlixI/IG4ExTFcU=
+github.com/onflow/flowkit/v2 v2.0.0-stable-cadence-alpha.18 h1:vgQ1SpQ9mpTX+c6x1hm71DmaLnHoMr3kIG479Ye0ll4=
+github.com/onflow/flowkit/v2 v2.0.0-stable-cadence-alpha.18/go.mod h1:uQiVIHhm6dXrXDM9SQG00FIaEQgh+TdVvM+ortvpF+M=
 github.com/onflow/go-ethereum v1.13.4 h1:iNO86fm8RbBbhZ87ZulblInqCdHnAQVY8okBrNsTevc=
 github.com/onflow/go-ethereum v1.13.4/go.mod h1:cE/gEUkAffhwbVmMJYz+t1dAfVNHNwZCgc3BWtZxBGY=
 github.com/onflow/sdks v0.5.1-0.20230912225508-b35402f12bba h1:rIehuhO6bj4FkwE4VzwEjX7MoAlOhUJENBJLqDqVxAo=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-preview.25](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.25)
- [onflow/flow-go-sdk v1.0.0-preview.25](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.25)
- [onflow/flow-go v0.34.0-crescendo-preview.18](https://github.com/onflow/flow-go/releases/tag/v0.34.0-crescendo-preview.18)
- [onflow/flow-emulator v1.0.0-preview.22](https://github.com/onflow/flow-emulator/releases/tag/v1.0.0-preview.22)
- [onflow/cadence-tools/lint v1.0.0-preview.16](https://github.com/onflow/cadence-tools/lint/releases/tag/v1.0.0-preview.16)
- [onflow/cadence-tools/test v1.0.0-preview.15](https://github.com/onflow/cadence-tools/test/releases/tag/v1.0.0-preview.15)
- [onflow/flowkit/v2 v2.0.0-stable-cadence-alpha.18](https://github.com/onflow/flowkit/v2/releases/tag/v2.0.0-stable-cadence-alpha.18)

