### PR TITLE
[lint] Update to Cadence v1.0.0-preview.29

### DIFF
--- a/lint/go.mod
+++ b/lint/go.mod
@@ -4,8 +4,8 @@ go 1.20
 
 require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v1.0.0-preview.28
-	github.com/onflow/flow-go-sdk v1.0.0-preview.28
+	github.com/onflow/cadence v1.0.0-preview.29
+	github.com/onflow/flow-go-sdk v1.0.0-preview.30
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
 	google.golang.org/grpc v1.63.2

--- a/lint/go.sum
+++ b/lint/go.sum
@@ -40,12 +40,12 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/onflow/atree v0.7.0-rc.2 h1:mZmVrl/zPlfI44EjV3FdR2QwIqT8nz1sCONUBFcML/U=
 github.com/onflow/atree v0.7.0-rc.2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/cadence v1.0.0-preview.28 h1:HUGwDFS3GRp1OB5AHXzz+UeZmDgWfvuJeJsmztwswjI=
-github.com/onflow/cadence v1.0.0-preview.28/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
+github.com/onflow/cadence v1.0.0-preview.29 h1:kuglA1LXKsti1JWhZ25riVkIZsLnyiudF8fgzeblZ40=
+github.com/onflow/cadence v1.0.0-preview.29/go.mod h1:3LM1VgE9HkJ815whY/F0LYWULwJa8p2nJiKyIIxpGAE=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
-github.com/onflow/flow-go-sdk v1.0.0-preview.28 h1:y/HUyOfzo+f4WyRRoWWn4KfBzX/0iAzf5O99Xq8fwjI=
-github.com/onflow/flow-go-sdk v1.0.0-preview.28/go.mod h1:6CyisRZsC3KfOIzonTEt13202U0MyaVIEXZmPBfYQF8=
+github.com/onflow/flow-go-sdk v1.0.0-preview.30 h1:62IwC7l8Uw1mxoZe7ewJII0HFHLUMsg04z1BW3JSEfM=
+github.com/onflow/flow-go-sdk v1.0.0-preview.30/go.mod h1:PBIk3vLqU1aLdbWPw7ljRDmwSGLcsuk/ipL9eLMgWwc=
 github.com/onflow/flow/protobuf/go/flow v0.4.0 h1:5TGmPwRmnSt7aawgtPGF9ehoGHHir9Cy9LVoAiU9t/E=
 github.com/onflow/flow/protobuf/go/flow v0.4.0/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/go-ethereum v1.13.4 h1:iNO86fm8RbBbhZ87ZulblInqCdHnAQVY8okBrNsTevc=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-preview.29](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.29)
- [onflow/flow-go-sdk v1.0.0-preview.30](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.30)

