### PR TITLE
[lint] Update to Cadence v1.0.0-preview.37

### DIFF
--- a/lint/go.mod
+++ b/lint/go.mod
@@ -6,8 +6,8 @@ toolchain go1.22.3
 
 require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v1.0.0-preview.35
-	github.com/onflow/flow-go-sdk v1.0.0-preview.37
+	github.com/onflow/cadence v1.0.0-preview.37
+	github.com/onflow/flow-go-sdk v1.0.0-preview.39
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/grpc v1.63.2
 )

--- a/lint/go.sum
+++ b/lint/go.sum
@@ -43,12 +43,12 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/onflow/atree v0.7.0-rc.2 h1:mZmVrl/zPlfI44EjV3FdR2QwIqT8nz1sCONUBFcML/U=
 github.com/onflow/atree v0.7.0-rc.2/go.mod h1:xvP61FoOs95K7IYdIYRnNcYQGf4nbF/uuJ0tHf4DRuM=
-github.com/onflow/cadence v1.0.0-preview.35 h1:HZgt/9Foa6sCSH9SNaIFUSXK6q2ZxETg0ivsZbf+hhU=
-github.com/onflow/cadence v1.0.0-preview.35/go.mod h1:jOwvPSSLTr9TvaKMs7KKiBYMmpdpNNAFxBsjMlrqVD0=
+github.com/onflow/cadence v1.0.0-preview.37 h1:CclIG7GXEBJCwk5d5jumJ6cU8xj/Q1A9cfVJKIxvLH8=
+github.com/onflow/cadence v1.0.0-preview.37/go.mod h1:jOwvPSSLTr9TvaKMs7KKiBYMmpdpNNAFxBsjMlrqVD0=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
-github.com/onflow/flow-go-sdk v1.0.0-preview.37 h1:ujeIQheD+skzFt9+eOT9nXcc1rFxVLSCzwisEI3+2DA=
-github.com/onflow/flow-go-sdk v1.0.0-preview.37/go.mod h1:2aSN7RdKzxWoCtCyOJz9W/ZNqkLgQDQS3hKLYwPlvGw=
+github.com/onflow/flow-go-sdk v1.0.0-preview.39 h1:LAFqq8fph9BnnbYO/PuT4+bZHrfDCZOBG9RytJbrBZ4=
+github.com/onflow/flow-go-sdk v1.0.0-preview.39/go.mod h1:/72XLyAy6//wS4Xnt2sp6FgR+MtWPqrLwrkVzbjSE44=
 github.com/onflow/flow/protobuf/go/flow v0.4.3 h1:gdY7Ftto8dtU+0wI+6ZgW4oE+z0DSDUMIDwVx8mqae8=
 github.com/onflow/flow/protobuf/go/flow v0.4.3/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/go-ethereum v1.13.4 h1:iNO86fm8RbBbhZ87ZulblInqCdHnAQVY8okBrNsTevc=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-preview.37](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.37)
- [onflow/flow-go-sdk v1.0.0-preview.39](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.39)

