### PR TITLE
[lint] Update to Cadence v1.0.0-preview.42

### DIFF
--- a/lint/go.mod
+++ b/lint/go.mod
@@ -6,8 +6,8 @@ toolchain go1.22.3
 
 require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v1.0.0-preview.41
-	github.com/onflow/flow-go-sdk v1.0.0-preview.44
+	github.com/onflow/cadence v1.0.0-preview.42
+	github.com/onflow/flow-go-sdk v1.0.0-preview.45
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/grpc v1.63.2
 )

--- a/lint/go.sum
+++ b/lint/go.sum
@@ -43,12 +43,12 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/onflow/atree v0.8.0-rc.5 h1:1sU+c6UfDzq/EjM8nTw4EI8GvEMarcxkWkJKy6piFSY=
 github.com/onflow/atree v0.8.0-rc.5/go.mod h1:yccR+LR7xc1Jdic0mrjocbHvUD7lnVvg8/Ct1AA5zBo=
-github.com/onflow/cadence v1.0.0-preview.41 h1:nEfnCF8IA/+i31twFKOimzbDVUo4tOlaqBtlDaGB4qM=
-github.com/onflow/cadence v1.0.0-preview.41/go.mod h1:BCoenp1TYp+SmG7FGWStjehvvzcvNQ3xvpK5rkthq3Y=
+github.com/onflow/cadence v1.0.0-preview.42 h1:oJYGxKn/oMiJnhwbuviSQRJFAFiNKcEt6YBqNX61Bu4=
+github.com/onflow/cadence v1.0.0-preview.42/go.mod h1:BCoenp1TYp+SmG7FGWStjehvvzcvNQ3xvpK5rkthq3Y=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
-github.com/onflow/flow-go-sdk v1.0.0-preview.44 h1:KgO5OedGS94UPDRpnvPH4bEfNKt4VI8BP16rY+LCuQE=
-github.com/onflow/flow-go-sdk v1.0.0-preview.44/go.mod h1:TWKQyGN2rrTlMem1g8ATOHOKJfjjzLUwjJsoe7vLfxY=
+github.com/onflow/flow-go-sdk v1.0.0-preview.45 h1:cbxKT2Z1umA4Vib0t28xHiFrygZyyjBqIcYGaeE9dzg=
+github.com/onflow/flow-go-sdk v1.0.0-preview.45/go.mod h1:26E0SDbNHkxtBnxOatQi3tpAh8tehsV8gt/8IH2nyww=
 github.com/onflow/flow/protobuf/go/flow v0.4.3 h1:gdY7Ftto8dtU+0wI+6ZgW4oE+z0DSDUMIDwVx8mqae8=
 github.com/onflow/flow/protobuf/go/flow v0.4.3/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/go-ethereum v1.13.4 h1:iNO86fm8RbBbhZ87ZulblInqCdHnAQVY8okBrNsTevc=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-preview.42](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.42)
- [onflow/flow-go-sdk v1.0.0-preview.45](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.45)

