### PR TITLE
[lint] Update to Cadence v1.0.0-preview.50

### DIFF
--- a/lint/go.mod
+++ b/lint/go.mod
@@ -6,8 +6,8 @@ toolchain go1.22.3
 
 require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/onflow/cadence v1.0.0-preview.49
-	github.com/onflow/flow-go-sdk v1.0.0-preview.51
+	github.com/onflow/cadence v1.0.0-preview.50
+	github.com/onflow/flow-go-sdk v1.0.0-preview.53
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/grpc v1.63.2
 )

--- a/lint/go.sum
+++ b/lint/go.sum
@@ -43,12 +43,12 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/onflow/atree v0.8.0-rc.6 h1:GWgaylK24b5ta2Hq+TvyOF7X5tZLiLzMMn7lEt59fsA=
 github.com/onflow/atree v0.8.0-rc.6/go.mod h1:yccR+LR7xc1Jdic0mrjocbHvUD7lnVvg8/Ct1AA5zBo=
-github.com/onflow/cadence v1.0.0-preview.49 h1:MXy6qAtFyRSnqSVKpDkh2J1sb2JEryJoYy/5qsaixlw=
-github.com/onflow/cadence v1.0.0-preview.49/go.mod h1:7wvvecnAZtYOspLOS3Lh+FuAmMeSrXhAWiycC3kQ1UU=
+github.com/onflow/cadence v1.0.0-preview.50 h1:sEfUOG7BXzEqPzB68yZZrG/lkBmHf/o0poYDCY18x3A=
+github.com/onflow/cadence v1.0.0-preview.50/go.mod h1:7wvvecnAZtYOspLOS3Lh+FuAmMeSrXhAWiycC3kQ1UU=
 github.com/onflow/crypto v0.25.1 h1:0txy2PKPMM873JbpxQNbJmuOJtD56bfs48RQfm0ts5A=
 github.com/onflow/crypto v0.25.1/go.mod h1:C8FbaX0x8y+FxWjbkHy0Q4EASCDR9bSPWZqlpCLYyVI=
-github.com/onflow/flow-go-sdk v1.0.0-preview.51 h1:rsvjyEdiot4oKwx2YsEqV2hsXqDrakuVmSUexsU/lSI=
-github.com/onflow/flow-go-sdk v1.0.0-preview.51/go.mod h1:yXinctVJY1VlpQaJhkCUMiC5lvv2kYCCMdMo+FdSV5A=
+github.com/onflow/flow-go-sdk v1.0.0-preview.53 h1:hF6X5b9gVQoc/wUa5JTcYU6tw1B7aW71XDdfsFhU5Gw=
+github.com/onflow/flow-go-sdk v1.0.0-preview.53/go.mod h1:FtsoOHw5RNmMMwC7jI1hc99ZVJWhnm/gE3OMvFaZjyg=
 github.com/onflow/flow/protobuf/go/flow v0.4.3 h1:gdY7Ftto8dtU+0wI+6ZgW4oE+z0DSDUMIDwVx8mqae8=
 github.com/onflow/flow/protobuf/go/flow v0.4.3/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/go-ethereum v1.13.4 h1:iNO86fm8RbBbhZ87ZulblInqCdHnAQVY8okBrNsTevc=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.0.0-preview.50](https://github.com/onflow/cadence/releases/tag/v1.0.0-preview.50)
- [onflow/flow-go-sdk v1.0.0-preview.53](https://github.com/onflow/flow-go-sdk/releases/tag/v1.0.0-preview.53)

