### PR TITLE
[LS] Update access modifiers to Cadence 1.0

### DIFF
--- a/languageserver/server/document_test.go
+++ b/languageserver/server/document_test.go
@@ -41,20 +41,20 @@ func TestDocument_HasAnyPrecedingStringsAtPosition(t *testing.T) {
 
 		t.Parallel()
 
-		doc := Document{Text: "  pub \t  \n  f"}
+		doc := Document{Text: "  access(all) \t  \n  f"}
 
-		assert.True(t, doc.HasAnyPrecedingStringsAtPosition([]string{"pub"}, 2, 1))
-		assert.True(t, doc.HasAnyPrecedingStringsAtPosition([]string{"pub"}, 2, 2))
-		assert.True(t, doc.HasAnyPrecedingStringsAtPosition([]string{"pub"}, 2, 3))
-		assert.True(t, doc.HasAnyPrecedingStringsAtPosition([]string{"access(self)", "pub"}, 2, 2))
-		assert.True(t, doc.HasAnyPrecedingStringsAtPosition([]string{"access(self)", "pub"}, 1, 6))
+		assert.True(t, doc.HasAnyPrecedingStringsAtPosition([]string{"access(all)"}, 2, 1))
+		assert.True(t, doc.HasAnyPrecedingStringsAtPosition([]string{"access(all)"}, 2, 2))
+		assert.True(t, doc.HasAnyPrecedingStringsAtPosition([]string{"access(all)"}, 2, 3))
+		assert.True(t, doc.HasAnyPrecedingStringsAtPosition([]string{"access(self)", "access(all)"}, 2, 2))
+		assert.True(t, doc.HasAnyPrecedingStringsAtPosition([]string{"access(self)", "access(all)"}, 1, 13))
 	})
 
 	t.Run("invalid", func(t *testing.T) {
 
 		t.Parallel()
 
-		doc := Document{Text: "  pub \t  \n  f"}
+		doc := Document{Text: "  access(all) \t  \n  f"}
 
 		assert.False(t, doc.HasAnyPrecedingStringsAtPosition([]string{"access(self)"}, 2, 2))
 	})

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -1129,11 +1129,8 @@ var expressionCompletionItems = []*protocol.CompletionItem{
 	},
 }
 
-var allAccessOptions = []string{"pub", "priv", "pub(set)", "access(contract)", "access(account)", "access(self)"}
+var allAccessOptions = []string{"access(all)", "access(contract)", "access(account)", "access(self)"}
 var allAccessOptionsCommaSeparated = strings.Join(allAccessOptions, ",")
-
-var readAccessOptions = []string{"pub", "priv", "access(contract)", "access(account)", "access(self)"}
-var readAccessOptionsCommaSeparated = strings.Join(readAccessOptions, ",")
 
 // NOTE: if the document doesn't specify an access modifier yet,
 // the completion item's InsertText will  get prefixed with a placeholder
@@ -1287,7 +1284,7 @@ func (s *Server) Completion(
 		if requiresAccessModifierPlaceholder {
 			item = withCompletionItemInsertText(
 				item,
-				fmt.Sprintf("${1|%s|} %s", readAccessOptionsCommaSeparated, item.InsertText),
+				fmt.Sprintf("${1|%s|} %s", allAccessOptionsCommaSeparated, item.InsertText),
 			)
 		}
 		items = append(items, item)


### PR DESCRIPTION
## Description

`pub`, `priv`, and `pub(set)` got removed in Cadence 1.0, so they should not be proposed anymore. Instead propose `access(all)`

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
