### PR TITLE
[Test] Update to Cadence v1.6.0

### DIFF
--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -148,7 +148,6 @@ var systemContracts = func() []common.AddressLocation {
 		"NFTStorefrontV2":                chainContracts.NonFungibleToken.Address.HexWithPrefix(),
 		"USDCFlow":                       chainContracts.FungibleToken.Address.HexWithPrefix(),
 		"FlowExecutionParameters":        chainContracts.ExecutionParametersAccount.Address.Hex(),
-		"AccountV2Migration":             chainContracts.AccountV2Migration.Address.HexWithPrefix(),
 		"Migration":                      chainContracts.Migration.Address.HexWithPrefix(),
 		"CrossVMMetadataViews":           serviceAddress,
 		"CrossVMNFT":                     serviceAddress,
@@ -257,14 +256,14 @@ func accountContractNames(blockchain *emulator.Blockchain, address flow.Address)
 }
 
 func (e *EmulatorBackend) RunScript(
-	inter *interpreter.Interpreter,
+	context stdlib.TestFrameworkScriptExecutionContext,
 	code string,
 	args []interpreter.Value,
 ) *stdlib.ScriptResult {
 
 	arguments := make([][]byte, 0, len(args))
 	for _, arg := range args {
-		exportedValue, err := runtime.ExportValue(arg, inter, interpreter.EmptyLocationRange)
+		exportedValue, err := runtime.ExportValue(arg, context, interpreter.EmptyLocationRange)
 		if err != nil {
 			return &stdlib.ScriptResult{
 				Error: err,
@@ -296,15 +295,15 @@ func (e *EmulatorBackend) RunScript(
 		}
 	}
 
-	staticType := runtime.ImportType(inter, result.Value.Type())
-	expectedType, err := inter.ConvertStaticToSemaType(staticType)
+	staticType := runtime.ImportType(context, result.Value.Type())
+	expectedType, err := interpreter.ConvertStaticToSemaType(context, staticType)
 	if err != nil {
 		return &stdlib.ScriptResult{
 			Error: err,
 		}
 	}
 	value, err := runtime.ImportValue(
-		inter,
+		context,
 		interpreter.EmptyLocationRange,
 		e.stdlibHandler,
 		e.locationHandler,
@@ -402,7 +401,7 @@ func (e *EmulatorBackend) GetAccount(
 }
 
 func (e *EmulatorBackend) AddTransaction(
-	inter *interpreter.Interpreter,
+	context stdlib.TestFrameworkAddTransactionContext,
 	code string,
 	authorizers []common.Address,
 	signers []*stdlib.Account,
@@ -414,7 +413,7 @@ func (e *EmulatorBackend) AddTransaction(
 	tx := e.newTransaction(code, authorizers)
 
 	for _, arg := range args {
-		exportedValue, err := runtime.ExportValue(arg, inter, interpreter.EmptyLocationRange)
+		exportedValue, err := runtime.ExportValue(arg, context, interpreter.EmptyLocationRange)
 		if err != nil {
 			return err
 		}
@@ -476,7 +475,7 @@ func (e *EmulatorBackend) CommitBlock() error {
 }
 
 func (e *EmulatorBackend) DeployContract(
-	inter *interpreter.Interpreter,
+	context stdlib.TestFrameworkContractDeploymentContext,
 	name string,
 	path string,
 	args []interpreter.Value,
@@ -504,7 +503,7 @@ func (e *EmulatorBackend) DeployContract(
 	var txArgsBuilder, addArgsBuilder strings.Builder
 
 	for i, arg := range args {
-		cadenceArg, err := runtime.ExportValue(arg, inter, interpreter.EmptyLocationRange)
+		cadenceArg, err := runtime.ExportValue(arg, context, interpreter.EmptyLocationRange)
 		if err != nil {
 			return err
 		}
@@ -588,7 +587,7 @@ func (e *EmulatorBackend) Reset(height uint64) {
 // Events returns all the emitted events up until the latest block,
 // optionally filtered by event type.
 func (e *EmulatorBackend) Events(
-	inter *interpreter.Interpreter,
+	context stdlib.TestFrameworkEventsContext,
 	eventType interpreter.StaticType,
 ) interpreter.Value {
 	latestBlock, err := e.blockchain.GetLatestBlock()
@@ -623,7 +622,7 @@ func (e *EmulatorBackend) Events(
 
 		for _, event := range sdkEvents {
 			value, err := runtime.ImportValue(
-				inter,
+				context,
 				interpreter.EmptyLocationRange,
 				e.stdlibHandler,
 				e.locationHandler,
@@ -640,15 +639,15 @@ func (e *EmulatorBackend) Events(
 	}
 
 	arrayType := interpreter.NewVariableSizedStaticType(
-		inter,
+		context,
 		interpreter.NewPrimitiveStaticType(
-			inter,
+			context,
 			interpreter.PrimitiveStaticTypeAnyStruct,
 		),
 	)
 
 	return interpreter.NewArrayValue(
-		inter,
+		context,
 		interpreter.EmptyLocationRange,
 		arrayType,
 		common.ZeroAddress,

--- a/test/go.mod
+++ b/test/go.mod
@@ -211,3 +211,5 @@ require (
 	modernc.org/sqlite v1.28.0 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
+
+replace github.com/onflow/cadence => ../../cadence

--- a/test/go.mod
+++ b/test/go.mod
@@ -211,5 +211,3 @@ require (
 	modernc.org/sqlite v1.28.0 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
-
-replace github.com/onflow/cadence => ../../cadence

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -1179,7 +1179,8 @@ func TestUsingEnv(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Error(t, result.Error)
-		publicKeyError := interpreter.InvalidPublicKeyError{}
+
+		var publicKeyError *interpreter.InvalidPublicKeyError
 		assert.ErrorAs(t, result.Error, &publicKeyError)
 	})
 
@@ -2214,11 +2215,17 @@ func TestPrettyPrintTestResults(t *testing.T) {
 			error: assertion failed: unexpected error occurred
 			 --> tests/test_script.cdc:9:12
 			
+			Was this error unhelpful?
+			Consider suggesting an improvement here: https://github.com/onflow/cadence/issues.
+			
 - PASS: testFunc3
 - FAIL: testFunc4
 		Execution failed:
 			error: panic: runtime error
 			  --> tests/test_script.cdc:17:12
+			
+			Was this error unhelpful?
+			Consider suggesting an improvement here: https://github.com/onflow/cadence/issues.
 			
 `
 
@@ -2713,8 +2720,11 @@ func TestInterpretMatcher(t *testing.T) {
 		runner := NewTestRunner()
 		result, err := runner.RunTest(script, "test")
 		require.NoError(t, err)
+
 		require.Error(t, result.Error)
-		assert.ErrorAs(t, result.Error, &interpreter.TypeMismatchError{})
+
+		var typeMismatchErr *interpreter.TypeMismatchError
+		assert.ErrorAs(t, result.Error, &typeMismatchErr)
 	})
 
 	t.Run("custom resource matcher", func(t *testing.T) {
@@ -2841,8 +2851,11 @@ func TestInterpretMatcher(t *testing.T) {
 		runner := NewTestRunner()
 		result, err := runner.RunTest(script, "test")
 		require.NoError(t, err)
+
 		require.Error(t, result.Error)
-		assert.ErrorAs(t, result.Error, &interpreter.TypeMismatchError{})
+
+		var typeMismatchErr *interpreter.TypeMismatchError
+		assert.ErrorAs(t, result.Error, &typeMismatchErr)
 	})
 }
 
@@ -3162,8 +3175,11 @@ func TestInterpretExpectFunction(t *testing.T) {
 		runner := NewTestRunner()
 		result, err := runner.RunTest(script, "test")
 		require.NoError(t, err)
+
 		require.Error(t, result.Error)
-		assert.ErrorAs(t, result.Error, &interpreter.TypeMismatchError{})
+
+		var typeMismatchErr *interpreter.TypeMismatchError
+		assert.ErrorAs(t, result.Error, &typeMismatchErr)
 	})
 
 	t.Run("with explicit types", func(t *testing.T) {
@@ -4258,7 +4274,6 @@ func TestCoverageReportForUnitTests(t *testing.T) {
 			"A.0000000000000001.NFTStorefrontV2",
 			"A.0000000000000002.USDCFlow",
 			"A.0000000000000002.FlowExecutionParameters",
-			"A.0000000000000001.AccountV2Migration",
 			"A.0000000000000001.Migration",
 			"A.0000000000000001.CrossVMMetadataViews",
 			"A.0000000000000001.CrossVMNFT",
@@ -4509,7 +4524,6 @@ func TestCoverageReportForIntegrationTests(t *testing.T) {
 			"A.0000000000000001.Crypto",
 			"A.0000000000000002.USDCFlow",
 			"A.0000000000000002.FlowExecutionParameters",
-			"A.0000000000000001.AccountV2Migration",
 			"A.0000000000000001.Migration",
 			"A.0000000000000001.CrossVMMetadataViews",
 			"A.0000000000000001.CrossVMNFT",


### PR DESCRIPTION
Depends on / work towards #470 

## Description

- `AccountV2Migration` was removed from flow-go, as the migration to V2 is complete
- Switch parameters to use the respective context interfaces instead of the interpreter
- Interpreter errors are pointer types now
- `StorageFormatV2Enabled` feature flag was removed, it is now always enabled

This required several changes to Cadence: https://github.com/onflow/cadence/pull/4018

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
