### PR TITLE
[LS] Improve hover

### DIFF
--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -657,6 +657,15 @@ func (s *Server) Hover(
 
 	position := conversion.ProtocolToSemaPosition(params.Position)
 	occurrence := checker.PositionInfo.Occurrences.Find(position)
+	if occurrence == nil {
+		// If no occurrence is found,
+		// then try the preceding position
+		if position.Column > 0 {
+			previousPosition := position
+			previousPosition.Column -= 1
+			occurrence = checker.PositionInfo.Occurrences.Find(previousPosition)
+		}
+	}
 
 	if occurrence == nil || occurrence.Origin == nil {
 		return nil, nil


### PR DESCRIPTION
Work towards #467 

## Description

When hovering at the end of a member identifier, lookup fails because the column is outside of the identifier. 
Re-attempt occurrence lookup with the preceding position.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
