### PR TITLE
[lint] Improve unused result linter

### DIFF
--- a/lint/unused_result_analyzer.go
+++ b/lint/unused_result_analyzer.go
@@ -24,6 +24,19 @@ import (
 	"github.com/onflow/cadence/tools/analysis"
 )
 
+func reportUnusedResultType(ty sema.Type) bool {
+	switch ty {
+	case nil, sema.VoidType, sema.NeverType:
+		return false
+	}
+
+	if optionalType, ok := ty.(*sema.OptionalType); ok {
+		return reportUnusedResultType(optionalType.Type)
+	}
+
+	return true
+}
+
 var UnusedResultAnalyzer = (func() *analysis.Analyzer {
 
 	elementFilter := []ast.Element{
@@ -53,10 +66,7 @@ var UnusedResultAnalyzer = (func() *analysis.Analyzer {
 					}
 
 					ty := elaboration.ExpressionTypes(expressionStatement.Expression).ActualType
-					switch ty {
-					case nil, sema.VoidType, sema.NeverType:
-						// NO-OP
-					default:
+					if reportUnusedResultType(ty) {
 						report(
 							analysis.Diagnostic{
 								Location: location,


### PR DESCRIPTION

## Description

Don't report unused result when calling void function via optional chaining.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
