### PR TITLE
[lint] Add a new analyzer which detects leaks of authority

### DIFF
--- a/lint/analyzer.go
+++ b/lint/analyzer.go
@@ -32,6 +32,7 @@ const (
 	UnusedResultCategory    = "unused-result-hint"
 	DeprecatedCategory      = "deprecated"
 	CadenceV1Category       = "cadence-v1"
+	SecurityCategory        = "security"
 )
 
 var Analyzers = map[string]*analysis.Analyzer{}

--- a/lint/authority_leak_analyzer.go
+++ b/lint/authority_leak_analyzer.go
@@ -1,0 +1,145 @@
+/*
+ * Cadence lint - The Cadence linter
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lint
+
+import (
+	"fmt"
+
+	"github.com/onflow/cadence/ast"
+	"github.com/onflow/cadence/common"
+	"github.com/onflow/cadence/sema"
+	"github.com/onflow/cadence/tools/analysis"
+)
+
+var AuthorityLeakAnalyzer = (func() *analysis.Analyzer {
+
+	return &analysis.Analyzer{
+		Description: "Detects leaks of authority, e.g. public fields exposing (capabilities of) entitled references",
+		Run: func(pass *analysis.Pass) interface{} {
+
+			report := pass.Report
+			program := pass.Program
+			elaboration := program.Checker.Elaboration
+
+			for _, compositeDeclaration := range pass.Program.Program.CompositeDeclarations() {
+				compositeType := elaboration.CompositeDeclarationType(compositeDeclaration)
+				if compositeType == nil {
+					continue
+				}
+
+				fieldDeclarations := compositeDeclaration.Members.FieldsByIdentifier()
+
+				compositeType.Members.Foreach(func(memberName string, member *sema.Member) {
+					// Only check public fields
+					if member.DeclarationKind != common.DeclarationKindField ||
+						member.Access != sema.PrimitiveAccess(ast.AccessAll) {
+
+						return
+					}
+
+					if isOrContainsType(
+						member.TypeAnnotation.Type,
+						isEntitledReferenceOrCapability,
+					) {
+						fieldDeclaration, ok := fieldDeclarations[memberName]
+						if !ok {
+							return
+						}
+
+						report(
+							analysis.Diagnostic{
+								Location: pass.Program.Location,
+								Range:    fieldDeclaration.Range,
+								Category: SecurityCategory,
+								Message: fmt.Sprintf(
+									"field '%s' of %s '%s' exposes (a capability of) an entitled reference, "+
+										"which may lead to authority leaks",
+									memberName,
+									compositeDeclaration.DeclarationKind().Name(),
+									compositeType.QualifiedString(),
+								),
+								SecondaryMessage: "consider restricting access to the field " +
+									"or changing its type to avoid authority leaks",
+							},
+						)
+					}
+
+				})
+			}
+
+			return nil
+		},
+	}
+})()
+
+func isOrContainsType(ty sema.Type, f func(sema.Type) bool) bool {
+	if f(ty) {
+		return true
+	}
+
+	switch ty := ty.(type) {
+	case *sema.VariableSizedType:
+		return isOrContainsType(ty.Type, f)
+
+	case *sema.ConstantSizedType:
+		return isOrContainsType(ty.Type, f)
+
+	case *sema.DictionaryType:
+		return isOrContainsType(ty.KeyType, f) ||
+			isOrContainsType(ty.ValueType, f)
+
+	case *sema.OptionalType:
+		return isOrContainsType(ty.Type, f)
+	}
+
+	return false
+}
+
+// isEntitledReferenceOrCapability returns true if the given type is a (capability to an) entitled reference.
+func isEntitledReferenceOrCapability(ty sema.Type) bool {
+	// Consider only references and capabilities
+	var refType *sema.ReferenceType
+	switch ty := ty.(type) {
+	case *sema.CapabilityType:
+		refType, _ = ty.BorrowType.(*sema.ReferenceType)
+	case *sema.ReferenceType:
+		refType = ty
+	}
+	if refType == nil {
+		return false
+	}
+
+	// Check if the referenced type is entitled
+	switch refType.Authorization.(type) {
+	case *sema.EntitlementMapAccess,
+		sema.EntitlementSetAccess:
+
+		return true
+
+	default:
+		return false
+	}
+}
+
+func init() {
+	RegisterAnalyzer(
+		"authority-leak",
+		AuthorityLeakAnalyzer,
+	)
+}

--- a/lint/authority_leak_analyzer_test.go
+++ b/lint/authority_leak_analyzer_test.go
@@ -1,0 +1,303 @@
+/*
+ * Cadence lint - The Cadence linter
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lint_test
+
+import (
+	"testing"
+
+	"github.com/onflow/cadence/ast"
+	"github.com/onflow/cadence/tools/analysis"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence-tools/lint"
+)
+
+func TestAuthorityLeakAnalyzer(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("public unentitled reference", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+                access(all) struct S {
+                    access(all) let publicUnentitledReference: &Int?
+                    init() {
+                        self.publicUnentitledReference = nil
+                    }
+                }
+            `,
+			lint.AuthorityLeakAnalyzer,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic(nil),
+			diagnostics,
+		)
+	})
+
+	t.Run("public entitled reference", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+                access(all) struct S {
+                    access(all) let publicEntitledReference: (auth(Mutate) &Int)?
+                    init() {
+                        self.publicEntitledReference = nil
+                    }
+                }
+            `,
+			lint.AuthorityLeakAnalyzer,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic{
+				{
+					Location: testLocation,
+					Category: lint.SecurityCategory,
+					Message: "field 'publicEntitledReference' of structure 'S' exposes " +
+						"(a capability of) an entitled reference, which may lead to authority leaks",
+					SecondaryMessage: "consider restricting access to the field " +
+						"or changing its type to avoid authority leaks",
+					Range: ast.Range{
+						StartPos: ast.Position{
+							Offset: 60,
+							Line:   3,
+							Column: 20,
+						},
+						EndPos: ast.Position{
+							Offset: 120,
+							Line:   3,
+							Column: 80,
+						},
+					},
+				},
+			},
+			diagnostics,
+		)
+	})
+
+	t.Run("public entitled reference container", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+                access(all) struct S {
+                    access(all) let publicEntitledReferences: [auth(Mutate) &Int]
+                    init() {
+                        self.publicEntitledReferences = []
+                    }
+                }
+            `,
+			lint.AuthorityLeakAnalyzer,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic{
+				{
+					Location: testLocation,
+					Category: lint.SecurityCategory,
+					Message: "field 'publicEntitledReferences' of structure 'S' exposes " +
+						"(a capability of) an entitled reference, which may lead to authority leaks",
+					SecondaryMessage: "consider restricting access to the field " +
+						"or changing its type to avoid authority leaks",
+					Range: ast.Range{
+						StartPos: ast.Position{
+							Offset: 60,
+							Line:   3,
+							Column: 20,
+						},
+						EndPos: ast.Position{
+							Offset: 120,
+							Line:   3,
+							Column: 80,
+						},
+					},
+				},
+			},
+			diagnostics,
+		)
+	})
+
+	t.Run("private entitled reference", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+                access(all) struct S {
+                    access(self) let privateEntitledReference: (auth(Mutate) &Int)?
+                    init() {
+                        self.privateEntitledReference = nil
+                    }
+                }
+            `,
+			lint.AuthorityLeakAnalyzer,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic(nil),
+			diagnostics,
+		)
+	})
+
+	t.Run("public unentitled capability", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+                access(all) struct S {
+                    access(all) let publicUnentitledCapability: Capability<&Int>?
+                    init() {
+                        self.publicUnentitledCapability = nil
+                    }
+                }
+            `,
+			lint.AuthorityLeakAnalyzer,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic(nil),
+			diagnostics,
+		)
+	})
+
+	t.Run("public entitled capability", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+                access(all) struct S {
+                    access(all) let publicEntitledCapability: Capability<auth(Mutate) &Int>?
+                    init() {
+                        self.publicEntitledCapability = nil
+                    }
+                }
+            `,
+			lint.AuthorityLeakAnalyzer,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic{
+				{
+					Location: testLocation,
+					Category: lint.SecurityCategory,
+					Message: "field 'publicEntitledCapability' of structure 'S' exposes " +
+						"(a capability of) an entitled reference, which may lead to authority leaks",
+					SecondaryMessage: "consider restricting access to the field " +
+						"or changing its type to avoid authority leaks",
+					Range: ast.Range{
+						StartPos: ast.Position{
+							Offset: 60,
+							Line:   3,
+							Column: 20,
+						},
+						EndPos: ast.Position{
+							Offset: 131,
+							Line:   3,
+							Column: 91,
+						},
+					},
+				},
+			},
+			diagnostics,
+		)
+	})
+
+	t.Run("public entitled capability container", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+                access(all) struct S {
+                    access(all) let publicEntitledCapabilities: [Capability<auth(Mutate) &Int>]
+                    init() {
+                        self.publicEntitledCapabilities = []
+                    }
+                }
+            `,
+			lint.AuthorityLeakAnalyzer,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic{
+				{
+					Location: testLocation,
+					Category: lint.SecurityCategory,
+					Message: "field 'publicEntitledCapabilities' of structure 'S' exposes " +
+						"(a capability of) an entitled reference, which may lead to authority leaks",
+					SecondaryMessage: "consider restricting access to the field " +
+						"or changing its type to avoid authority leaks",
+					Range: ast.Range{
+						StartPos: ast.Position{
+							Offset: 60,
+							Line:   3,
+							Column: 20,
+						},
+						EndPos: ast.Position{
+							Offset: 134,
+							Line:   3,
+							Column: 94,
+						},
+					},
+				},
+			},
+			diagnostics,
+		)
+	})
+
+	t.Run("private entitled capability", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+                access(all) struct S {
+                    access(self) let privateEntitledCapability: Capability<auth(Mutate) &Int>?
+                    init() {
+                        self.privateEntitledCapability = nil
+                    }
+                }
+            `,
+			lint.AuthorityLeakAnalyzer,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic(nil),
+			diagnostics,
+		)
+	})
+
+}


### PR DESCRIPTION

Closes #6 

## Description

Detect leaks of authority, e.g. public fields exposing (capabilities of) entitled references.
I kept the name a bit more generic, as we might extend this in the future.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
