### PR TITLE
[lint] Ignore invalid type in unused result analyzer

### DIFF
--- a/lint/unused_result_analyzer.go
+++ b/lint/unused_result_analyzer.go
@@ -26,7 +26,7 @@ import (
 
 func reportUnusedResultType(ty sema.Type) bool {
 	switch ty {
-	case nil, sema.VoidType, sema.NeverType:
+	case nil, sema.VoidType, sema.NeverType, sema.InvalidType:
 		return false
 	}
 


### PR DESCRIPTION
## Description

Don't report false positives for functions with an invalid return type

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
