### PR TITLE
[lint] Add suggested fix to redundant cast diagnostic

### DIFF
--- a/lint/redundant_cast_analyzer.go
+++ b/lint/redundant_cast_analyzer.go
@@ -282,10 +282,6 @@ var RedundantCastAnalyzer = (func() *analysis.Analyzer {
 							EndPos:   castingExpression.TypeAnnotation.EndPosition(nil),
 						}
 
-						replacementStartOffset := castingExpression.Expression.StartPosition().Offset
-						replacementEndOffset := castingExpression.Expression.EndPosition(nil).Offset
-						replacement := string(program.Code[replacementStartOffset : replacementEndOffset+1])
-
 						report(
 							analysis.Diagnostic{
 								Location: location,
@@ -297,8 +293,8 @@ var RedundantCastAnalyzer = (func() *analysis.Analyzer {
 										Message: "Remove redundant cast",
 										TextEdits: []analysis.TextEdit{
 											{
-												Range:       ast.NewRangeFromPositioned(nil, castingExpression),
-												Replacement: replacement,
+												Range:       diagnosticRange,
+												Replacement: "",
 											},
 										},
 									},


### PR DESCRIPTION
## Description

When reporting a redundant cast, suggest fixing it by replacing the cast with just the casted expression.

Also improve the diagnostic message to not duplicate the type, and improve the range to include the operator, e.g.:

Before:

```cadence
let x = 1 as Int
//           ^^^
```

After:

```cadence
let x = 1 as Int
//       ^^^^^^^
```

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
