### PR TITLE
[LS] Optimize inlay hints

### DIFF
--- a/languageserver/protocol/range.go
+++ b/languageserver/protocol/range.go
@@ -1,0 +1,42 @@
+/*
+ * Cadence languageserver - The Cadence language server
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protocol
+
+func (r Range) Overlaps(other Range) bool {
+	return r.Start.Compare(other.End) <= 0 &&
+		r.End.Compare(other.Start) >= 0
+}
+
+func (p Position) Compare(other Position) int {
+	if p.Line < other.Line {
+		return -1
+	}
+
+	if p.Line > other.Line {
+		return 1
+	}
+
+	if p.Character < other.Character {
+		return -1
+	} else if p.Character > other.Character {
+		return 1
+	}
+
+	return 0
+}


### PR DESCRIPTION
## Description

When determining inlay hints (inferred type annotations for variable declarations), consider only variable declarations "in" requested range instead of all variable declarations in the document, which might be extensive in larger contracts.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
