### PR TITLE
[test] Update to Cadence v1.9.3

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.2
 	github.com/onflow/atree v0.12.0
 	github.com/onflow/cadence v1.9.3
-	github.com/onflow/flow-emulator v1.15.2-0.20260108233146-ba933aa8cc42
+	github.com/onflow/flow-emulator v1.15.2
 	github.com/onflow/flow-go v0.45.0-experimental-cadence-v1.8.7.0.20260107152219-757836bbe8dc
 	github.com/onflow/flow-go-sdk v1.9.9
 	github.com/onflow/flow/protobuf/go/flow v0.4.18

--- a/test/go.sum
+++ b/test/go.sum
@@ -598,8 +598,8 @@ github.com/onflow/flow-core-contracts/lib/go/contracts v1.9.2 h1:mkd1NSv74+OnCHw
 github.com/onflow/flow-core-contracts/lib/go/contracts v1.9.2/go.mod h1:jBDqVep0ICzhXky56YlyO4aiV2Jl/5r7wnqUPpvi7zE=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.9.2 h1:semxeVLwC6xFG1G/7egUmaf7F1C8eBnc7NxNTVfBHTs=
 github.com/onflow/flow-core-contracts/lib/go/templates v1.9.2/go.mod h1:twSVyUt3rNrgzAmxtBX+1Gw64QlPemy17cyvnXYy1Ug=
-github.com/onflow/flow-emulator v1.15.2-0.20260108233146-ba933aa8cc42 h1:6VwyKqpL3wE8cCCNHd5+jyD1LggNK1DOCDNXokeeMlE=
-github.com/onflow/flow-emulator v1.15.2-0.20260108233146-ba933aa8cc42/go.mod h1:NeEmzXzg6lelCe1PZ6EGzswPR1GCgTUbn9NvfN1t9HY=
+github.com/onflow/flow-emulator v1.15.2 h1:aHHm2hbgPoGAmXkeXU5j8v6Wy1rHDvmGd4fqWlKff/A=
+github.com/onflow/flow-emulator v1.15.2/go.mod h1:NeEmzXzg6lelCe1PZ6EGzswPR1GCgTUbn9NvfN1t9HY=
 github.com/onflow/flow-evm-bridge v0.1.0 h1:7X2osvo4NnQgHj8aERUmbYtv9FateX8liotoLnPL9nM=
 github.com/onflow/flow-evm-bridge v0.1.0/go.mod h1:5UYwsnu6WcBNrwitGFxphCl5yq7fbWYGYuiCSTVF6pk=
 github.com/onflow/flow-ft/lib/go/contracts v1.0.1 h1:Ts5ob+CoCY2EjEd0W6vdLJ7hLL3SsEftzXG2JlmSe24=


### PR DESCRIPTION

## Description

Automatically update to:
- [onflow/cadence v1.9.2](https://github.com/onflow/cadence/releases/tag/v1.9.2)
- [onflow/flow-go-sdk v1.9.8](https://github.com/onflow/flow-go-sdk/releases/tag/v1.9.8)
- [onflow/flow-go v0.44.17](https://github.com/onflow/flow-go/releases/tag/v0.44.17)
- [onflow/flow-emulator v1.15.1](https://github.com/onflow/flow-emulator/releases/tag/v1.15.1)

