### PR TITLE
[lint] Add a nil-check/force-unwrap analysis

### DIFF
--- a/lint/analyzer.go
+++ b/lint/analyzer.go
@@ -35,6 +35,7 @@ const (
 	CadenceV1Category                 = "cadence-v1"
 	SecurityCategory                  = "security"
 	ComplexityCategory                = "complexity"
+	IfLetHintCategory                 = "if-let-hint"
 )
 
 var Analyzers = map[string]*analysis.Analyzer{}

--- a/lint/iflet_analyzer.go
+++ b/lint/iflet_analyzer.go
@@ -1,0 +1,177 @@
+/*
+ * Cadence lint - The Cadence linter
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lint
+
+import (
+	"github.com/onflow/cadence/ast"
+	"github.com/onflow/cadence/tools/analysis"
+)
+
+var IfLetAnalyzer = (func() *analysis.Analyzer {
+
+	elementFilter := []ast.Element{
+		(*ast.IfStatement)(nil),
+		(*ast.ForceExpression)(nil),
+		(*ast.FunctionExpression)(nil),
+	}
+
+	return &analysis.Analyzer{
+		Description: "Detects if statements with nil checks followed by force-unwraps that should use if-let",
+		Requires: []*analysis.Analyzer{
+			analysis.InspectorAnalyzer,
+		},
+		Run: func(pass *analysis.Pass) interface{} {
+			inspector := pass.ResultOf[analysis.InspectorAnalyzer].(*ast.Inspector)
+
+			program := pass.Program
+			location := program.Location
+			report := pass.Report
+
+			// Track nil-checked expressions per scope
+			// Each function expression creates a new scope to handle parameter shadowing
+			type scope struct {
+				// Track nil-checked expressions in scope.
+				// Use the string representation as the key for easy comparison.
+				// Use a counter to handle nested if statements checking the same expression.
+				nilCheckedExprs map[string]int
+				// Track which nil-checked expressions we've already reported
+				// to avoid duplicate diagnostics (only report the first occurrence)
+				reportedExprs map[string]struct{}
+			}
+
+			var scopeStack []scope
+			pushScope := func() {
+				scopeStack = append(
+					scopeStack,
+					scope{
+						nilCheckedExprs: map[string]int{},
+						reportedExprs:   map[string]struct{}{},
+					},
+				)
+			}
+			pushScope()
+
+			inspector.Elements(
+				elementFilter,
+				func(element ast.Element, push bool) (cont bool) {
+					// By default, continue traversing the AST
+					cont = true
+
+					switch elem := element.(type) {
+					case *ast.FunctionExpression:
+						if push {
+							pushScope()
+						} else {
+							scopeStack = scopeStack[:len(scopeStack)-1]
+						}
+
+					case *ast.IfStatement:
+						currentScope := &scopeStack[len(scopeStack)-1]
+
+						if push {
+							// Entering an if statement.
+							// Track the nil-checked expression, if any
+							nilCheckedExpr := getNilCheckedExpression(elem)
+							if nilCheckedExpr != nil {
+								key := nilCheckedExpr.String()
+								currentScope.nilCheckedExprs[key] += 1
+							}
+						} else {
+							// Exiting an if statement.
+							// Remove the nil-checked expression
+							if len(currentScope.nilCheckedExprs) > 0 {
+								nilCheckedExpr := getNilCheckedExpression(elem)
+								if nilCheckedExpr != nil {
+									key := nilCheckedExpr.String()
+									currentScope.nilCheckedExprs[key] -= 1
+								}
+							}
+						}
+
+					case *ast.ForceExpression:
+						if !push {
+							return
+						}
+
+						// Check only the current scope
+						currentScope := &scopeStack[len(scopeStack)-1]
+
+						// Check if this force-unwrap's expression matches any nil-checked expression
+						key := elem.Expression.String()
+						if currentScope.nilCheckedExprs[key] > 0 {
+							// Only report if we haven't already reported this expression in this scope
+							if _, ok := currentScope.reportedExprs[key]; !ok {
+								report(
+									analysis.Diagnostic{
+										Location: location,
+										Range:    ast.NewRangeFromPositioned(nil, elem),
+										Category: IfLetHintCategory,
+										Message:  "consider using if-let instead of nil check followed by force-unwrap",
+										URL:      "https://cadence-lang.org/docs/language/control-flow#optional-binding",
+									},
+								)
+								currentScope.reportedExprs[key] = struct{}{}
+							}
+						}
+					}
+
+					return
+				},
+			)
+
+			return nil
+		},
+	}
+})()
+
+func getNilCheckedExpression(ifStmt *ast.IfStatement) ast.Expression {
+	binaryExpr, ok := ifStmt.Test.(*ast.BinaryExpression)
+	if !ok || binaryExpr.Operation != ast.OperationNotEqual {
+		return nil
+	}
+
+	var checkedExpr ast.Expression
+
+	if _, ok := binaryExpr.Right.(*ast.NilExpression); ok {
+		checkedExpr = binaryExpr.Left
+	} else if _, ok := binaryExpr.Left.(*ast.NilExpression); ok {
+		checkedExpr = binaryExpr.Right
+	} else {
+		return nil
+	}
+
+	// Only consider some expressions that are unlikely to have changed for now
+	// TODO: improve analysis to track writes and ensure the expression hasn't changed
+	switch checkedExpr.(type) {
+	case *ast.IdentifierExpression,
+		*ast.MemberExpression,
+		*ast.IndexExpression:
+
+		return checkedExpr
+	}
+
+	return nil
+}
+
+func init() {
+	RegisterAnalyzer(
+		"if-let",
+		IfLetAnalyzer,
+	)
+}

--- a/lint/iflet_analyzer_test.go
+++ b/lint/iflet_analyzer_test.go
@@ -1,0 +1,418 @@
+/*
+ * Cadence lint - The Cadence linter
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lint_test
+
+import (
+	"testing"
+
+	"github.com/onflow/cadence/ast"
+	"github.com/onflow/cadence/tools/analysis"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/cadence-tools/lint"
+)
+
+func TestIfLetAnalyzer(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("identifier expression", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+            access(all) contract Test {
+                access(all) fun test(opt: Int?) {
+                    if opt != nil {
+                        let val = opt!
+                    }
+                }
+            }
+            `,
+			lint.IfLetAnalyzer,
+		)
+
+		assert.Equal(t,
+			[]analysis.Diagnostic{
+				{
+					Location: testLocation,
+					Category: lint.IfLetHintCategory,
+					Message:  "consider using if-let instead of nil check followed by force-unwrap",
+					URL:      "https://cadence-lang.org/docs/language/control-flow#optional-binding",
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 161, Line: 5, Column: 34},
+						EndPos:   ast.Position{Offset: 164, Line: 5, Column: 37},
+					},
+				},
+			},
+			diagnostics,
+		)
+	})
+
+	t.Run("member expression", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+            access(all) contract Test {
+                access(all) struct Foo {
+                    access(all) var field: Int?
+                    init() {
+                        self.field = nil
+                    }
+                }
+
+                access(all) fun test(obj: Foo) {
+                    if obj.field != nil {
+                        let val = obj.field!
+                    }
+                }
+            }
+            `,
+			lint.IfLetAnalyzer,
+		)
+
+		assert.Equal(t,
+			[]analysis.Diagnostic{
+				{
+					Location: testLocation,
+					Category: lint.IfLetHintCategory,
+					Message:  "consider using if-let instead of nil check followed by force-unwrap",
+					URL:      "https://cadence-lang.org/docs/language/control-flow#optional-binding",
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 366, Line: 12, Column: 34},
+						EndPos:   ast.Position{Offset: 375, Line: 12, Column: 43},
+					},
+				},
+			},
+			diagnostics,
+		)
+	})
+
+	t.Run("index expression", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+            access(all) contract Test {
+                access(all) fun test(arr: [Int?]) {
+                    if arr[0] != nil {
+                        let val = arr[0]!
+                    }
+                }
+            }
+            `,
+			lint.IfLetAnalyzer,
+		)
+
+		assert.Equal(t,
+			[]analysis.Diagnostic{
+				{
+					Location: testLocation,
+					Category: lint.IfLetHintCategory,
+					Message:  "consider using if-let instead of nil check followed by force-unwrap",
+					URL:      "https://cadence-lang.org/docs/language/control-flow#optional-binding",
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 166, Line: 5, Column: 34},
+						EndPos:   ast.Position{Offset: 172, Line: 5, Column: 40},
+					},
+				},
+			},
+			diagnostics,
+		)
+	})
+
+	t.Run("nil on left side", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+            access(all) contract Test {
+                access(all) fun test(opt: Int?) {
+                    if nil != opt {
+                        let val = opt!
+                    }
+                }
+            }
+            `,
+			lint.IfLetAnalyzer,
+		)
+
+		assert.Equal(t,
+			[]analysis.Diagnostic{
+				{
+					Location: testLocation,
+					Category: lint.IfLetHintCategory,
+					Message:  "consider using if-let instead of nil check followed by force-unwrap",
+					URL:      "https://cadence-lang.org/docs/language/control-flow#optional-binding",
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 161, Line: 5, Column: 34},
+						EndPos:   ast.Position{Offset: 164, Line: 5, Column: 37},
+					},
+				},
+			},
+			diagnostics,
+		)
+	})
+
+	t.Run("other expression", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+            access(all) contract Test {
+                access(all) fun foo(): Int? {
+                    return 42
+                }
+
+                access(all) fun test() {
+                    if self.foo() != nil {
+                        let val = self.foo()!
+                    }
+                }
+            }
+            `,
+			lint.IfLetAnalyzer,
+		)
+
+		assert.Equal(t,
+			[]analysis.Diagnostic(nil),
+			diagnostics,
+		)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+            access(all) contract Test {
+                access(all) fun test(opt: Int?) {
+                    if opt == nil {
+                        let val = opt!
+                    }
+                }
+            }
+            `,
+			lint.IfLetAnalyzer,
+		)
+
+		assert.Equal(t,
+			[]analysis.Diagnostic(nil),
+			diagnostics,
+		)
+	})
+
+	t.Run("no force-unwrap", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+            access(all) contract Test {
+                access(all) fun test(opt: Int?) {
+                    if opt != nil {
+                        let x = opt
+                    }
+                }
+            }
+            `,
+			lint.IfLetAnalyzer,
+		)
+
+		assert.Equal(t,
+			[]analysis.Diagnostic(nil),
+			diagnostics,
+		)
+	})
+
+	t.Run("different expression", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+            access(all) contract Test {
+                access(all) fun test(opt: Int?, other: Int?) {
+                    if opt != nil {
+                        let val = other!
+                    }
+                }
+            }
+            `,
+			lint.IfLetAnalyzer,
+		)
+
+		assert.Equal(t,
+			[]analysis.Diagnostic(nil),
+			diagnostics,
+		)
+	})
+
+	t.Run("force-unwrap in function expression", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+            access(all) contract Test {
+                access(all) fun test(opt: Int?) {
+                    if opt != nil {
+                        let f = fun(opt: Int): Int {
+                            return opt + 1
+                        }
+                    }
+                }
+            }
+            `,
+			lint.IfLetAnalyzer,
+		)
+
+		assert.Equal(t,
+			[]analysis.Diagnostic(nil),
+			diagnostics,
+		)
+	})
+
+	t.Run("in function expression", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+            access(all) contract Test {
+                access(all) fun test(opt: Int?) {
+                    let f = fun(): Int {
+                        if opt != nil {
+                            return opt!
+                        }
+                        return 0
+                    }
+                }
+            }
+            `,
+			lint.IfLetAnalyzer,
+		)
+
+		// Should report because both check and unwrap are in the same scope (inside function expression)
+		assert.Equal(t,
+			[]analysis.Diagnostic{
+				{
+					Location: testLocation,
+					Category: lint.IfLetHintCategory,
+					Message:  "consider using if-let instead of nil check followed by force-unwrap",
+					URL:      "https://cadence-lang.org/docs/language/control-flow#optional-binding",
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 207, Line: 6, Column: 35},
+						EndPos:   ast.Position{Offset: 210, Line: 6, Column: 38},
+					},
+				},
+			},
+			diagnostics,
+		)
+	})
+
+	t.Run("only report first", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+            access(all) contract Test {
+                access(all) fun test(opt: Int?) {
+                    if opt != nil {
+                        let val1 = opt!
+                        let val2 = opt!
+                    }
+                }
+            }
+            `,
+			lint.IfLetAnalyzer,
+		)
+
+		assert.Equal(t,
+			[]analysis.Diagnostic{
+				{
+					Location: testLocation,
+					Category: lint.IfLetHintCategory,
+					Message:  "consider using if-let instead of nil check followed by force-unwrap",
+					URL:      "https://cadence-lang.org/docs/language/control-flow#optional-binding",
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 162, Line: 5, Column: 35},
+						EndPos:   ast.Position{Offset: 165, Line: 5, Column: 38},
+					},
+				},
+			},
+			diagnostics,
+		)
+	})
+
+	t.Run("nested", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+           access(all) contract Test {
+               access(all) fun test(x: Int?, y: Int?) {
+                   if x != nil {
+                       if y != nil {
+                           let a = x!
+                           let b = y!
+                       }
+                   }
+               }
+           }
+           `,
+			lint.IfLetAnalyzer,
+		)
+
+		assert.Equal(t,
+			[]analysis.Diagnostic{
+				{
+					Location: testLocation,
+					Category: lint.IfLetHintCategory,
+					Message:  "consider using if-let instead of nil check followed by force-unwrap",
+					URL:      "https://cadence-lang.org/docs/language/control-flow#optional-binding",
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 201, Line: 6, Column: 35},
+						EndPos:   ast.Position{Offset: 202, Line: 6, Column: 36},
+					},
+				},
+				{
+					Location: testLocation,
+					Category: lint.IfLetHintCategory,
+					Message:  "consider using if-let instead of nil check followed by force-unwrap",
+					URL:      "https://cadence-lang.org/docs/language/control-flow#optional-binding",
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 239, Line: 7, Column: 35},
+						EndPos:   ast.Position{Offset: 240, Line: 7, Column: 36},
+					},
+				},
+			},
+			diagnostics,
+		)
+	})
+}


### PR DESCRIPTION
## Description

Add an analysis which detects nil-check + force-unwrap and suggests the use of an if-let instead. This analysis is very basic and does not track changes to the nil-checked expression yet. However, it should be still useful in the majority of cases (checked value did not change)

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
