### PR TITLE
[LS] Fix function and constructor types in completion items

### DIFF
--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -1991,10 +1991,10 @@ func (s *Server) maybeResolveMember(uri protocol.DocumentURI, id string, result 
 		typeString := member.TypeAnnotation.Type.QualifiedString()
 
 		result.Detail = fmt.Sprintf(
-			"(function) %s.%s%s",
+			"(function) %s.%s: %s",
 			member.ContainerType.String(),
 			member.Identifier,
-			typeString[1:len(typeString)-1],
+			typeString,
 		)
 
 	case common.DeclarationKindStructure,
@@ -2032,7 +2032,7 @@ func (s *Server) maybeResolveRange(uri protocol.DocumentURI, id string, result *
 
 		result.Detail = fmt.Sprintf(
 			"(constructor) %s",
-			typeString[1:len(typeString)-1],
+			typeString,
 		)
 
 	} else {


### PR DESCRIPTION
## Description

Fix the detail of function and constructor completion items. Currently they are broken, the start and end is cut off:

<img width="912" height="160" alt="Screenshot 2026-02-05 at 2 28 17 PM" src="https://github.com/user-attachments/assets/389247e7-9e8b-4b9e-8596-6eb8b76b0abd" />

This was initially done because before Cadence v1.0, the syntax for function types was `((T, ..., U): R)`, since then it is `fun (T, ..., U): R`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
