### PR TITLE
[test] Downgrade onflow/flow/protobuf/go/flow to v0.4.19

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/onflow/flow-emulator v1.17.0
 	github.com/onflow/flow-go v0.47.0-ledger-service.1.0.20260306194353-7770192048a9
 	github.com/onflow/flow-go-sdk v1.9.16
-	github.com/onflow/flow/protobuf/go/flow v0.4.20
+	github.com/onflow/flow/protobuf/go/flow v0.4.19
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.79.2

--- a/test/go.sum
+++ b/test/go.sum
@@ -614,8 +614,8 @@ github.com/onflow/flow-nft/lib/go/contracts v1.3.0 h1:DmNop+O0EMyicZvhgdWboFG57x
 github.com/onflow/flow-nft/lib/go/contracts v1.3.0/go.mod h1:eZ9VMMNfCq0ho6kV25xJn1kXeCfxnkhj3MwF3ed08gY=
 github.com/onflow/flow-nft/lib/go/templates v1.3.0 h1:uGIBy4GEY6Z9hKP7sm5nA5kwvbvLWW4nWx5NN9Wg0II=
 github.com/onflow/flow-nft/lib/go/templates v1.3.0/go.mod h1:gVbb5fElaOwKhV5UEUjM+JQTjlsguHg2jwRupfM/nng=
-github.com/onflow/flow/protobuf/go/flow v0.4.20 h1:Ndq2l7Nu8p/RWNSRIRrpnBUpzfc5fYLEmHCFpJ9JGgo=
-github.com/onflow/flow/protobuf/go/flow v0.4.20/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
+github.com/onflow/flow/protobuf/go/flow v0.4.19 h1:oYQoHWT/Iu441tX908qhCy7pCWAtwDspVrWbFGoTH1o=
+github.com/onflow/flow/protobuf/go/flow v0.4.19/go.mod h1:NA2pX2nw8zuaxfKphhKsk00kWLwfd+tv8mS23YXO4Sk=
 github.com/onflow/go-ethereum v1.13.4 h1:iNO86fm8RbBbhZ87ZulblInqCdHnAQVY8okBrNsTevc=
 github.com/onflow/go-ethereum v1.13.4/go.mod h1:cE/gEUkAffhwbVmMJYz+t1dAfVNHNwZCgc3BWtZxBGY=
 github.com/onflow/nft-storefront/lib/go/contracts v1.0.0 h1:sxyWLqGm/p4EKT6DUlQESDG1ZNMN9GjPCm1gTq7NGfc=


### PR DESCRIPTION
## Description

In the previous dependency update, the protobufs were unintentionally updated ahead of their supported flow-go version https://github.com/onflow/cadence-tools/pull/595/changes.  Unfortunately, these breaking changes only surfaced within the Flow CLI build https://github.com/onflow/flow-cli/actions/runs/22965674140/job/66668402837.

This PR downgrades the protobuf package to that which is supported by our flow-go version https://github.com/onflow/flow-go/blob/7770192048a92af7ae257bf0d62265b776f5fcee/go.mod#L56

______

<!-- Complete: -->

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
