### PR TITLE
[lint] Don't report unused parameters for interface functions

### DIFF
--- a/lint/unused_variable_analyzer.go
+++ b/lint/unused_variable_analyzer.go
@@ -77,9 +77,11 @@ var UnusedVariableAnalyzer = (func() *analysis.Analyzer {
 					}
 
 				case *ast.FunctionDeclaration:
-					// Skip parameters in interface functions,
-					// as they cannot have a body
-					if push && inInterfaceDepth == 0 {
+					// Collect all parameter identifiers,
+					// but ignore non-default interface functions
+					if push && (inInterfaceDepth == 0 ||
+						(inInterfaceDepth > 0 && decl.FunctionBlock.HasStatements())) {
+
 						// Collect all parameter identifiers
 						for _, param := range decl.ParameterList.Parameters {
 							identifiers = append(

--- a/lint/unused_variable_analyzer_test.go
+++ b/lint/unused_variable_analyzer_test.go
@@ -657,6 +657,30 @@ func TestUnusedVariableAnalyzer(t *testing.T) {
 			[]analysis.Diagnostic{
 				{
 					Range: ast.Range{
+						StartPos: ast.Position{Offset: 88, Line: 3, Column: 38},
+						EndPos:   ast.Position{Offset: 90, Line: 3, Column: 40},
+					},
+					Location: testLocation,
+					Category: lint.UnusedVariableCategory,
+					Message:  "parameter 'baz' is declared but never used",
+					SuggestedFixes: []errors.SuggestedFix[ast.TextEdit]{
+						{
+							Message: "Add parameter name with underscore prefix",
+							TextEdits: []ast.TextEdit{
+								{
+									Replacement: "baz _baz",
+									Insertion:   "",
+									Range: ast.Range{
+										StartPos: ast.Position{Offset: 88, Line: 3, Column: 38},
+										EndPos:   ast.Position{Offset: 90, Line: 3, Column: 40},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Range: ast.Range{
 						StartPos: ast.Position{Offset: 126, Line: 4, Column: 26},
 						EndPos:   ast.Position{Offset: 131, Line: 4, Column: 31},
 					},


### PR DESCRIPTION

## Description

Parameters are usually not used in interface functions, so do not report them.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
