### PR TITLE
[lint] Fix false positive in redundant type annotation analyzer for nested empty literals

### DIFF
--- a/lint/redundant_cast_analyzer.go
+++ b/lint/redundant_cast_analyzer.go
@@ -78,6 +78,11 @@ func (d *CheckCastVisitor) VisitFixedPointExpression(expr *ast.FixedPointExpress
 }
 
 func (d *CheckCastVisitor) VisitArrayExpression(expr *ast.ArrayExpression) bool {
+	if len(expr.Values) == 0 {
+		// Empty array literals always need a type annotation
+		return false
+	}
+
 	// If the target type is `ConstantSizedType`, then it is not redundant.
 	// Because array literals are always inferred to be `VariableSizedType`,
 	// unless specified.
@@ -107,6 +112,11 @@ func (d *CheckCastVisitor) VisitArrayExpression(expr *ast.ArrayExpression) bool 
 }
 
 func (d *CheckCastVisitor) VisitDictionaryExpression(expr *ast.DictionaryExpression) bool {
+	if len(expr.Entries) == 0 {
+		// Empty dictionary literals always need a type annotation
+		return false
+	}
+
 	targetDictionaryType, ok := d.targetType.(*sema.DictionaryType)
 	if !ok {
 		return false
@@ -231,19 +241,6 @@ func (d *CheckCastVisitor) isTypeRedundant(exprType, targetType sema.Type) bool 
 //   - Case I: Contextually expected type is same as the casted type (target type).
 //   - Case II: Expression is self typed, and is same as the casted type (target type).
 func isRedundantCast(expr ast.Expression, exprInferredType, targetType, expectedType sema.Type) bool {
-
-	switch expr := expr.(type) {
-	case *ast.ArrayExpression:
-		if len(expr.Values) == 0 {
-			// Empty array literals need a type annotation
-			return false
-		}
-	case *ast.DictionaryExpression:
-		if len(expr.Entries) == 0 {
-			// Empty dictionary literals need a type annotation
-			return false
-		}
-	}
 
 	if expectedType != nil &&
 		!expectedType.IsInvalidType() &&

--- a/lint/redundant_type_annotation_analyzer_test.go
+++ b/lint/redundant_type_annotation_analyzer_test.go
@@ -181,4 +181,40 @@ func TestRedundantTypeAnnotationAnalyzer(t *testing.T) {
 			diagnostics,
 		)
 	})
+
+	t.Run("type annotation needed, nested empty dictionary", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+              access(all) let foo: {Int: {String: AnyStruct}} = {1: {}}
+            `,
+			lint.RedundantTypeAnnotationAnalyzer,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic(nil),
+			diagnostics,
+		)
+	})
+
+	t.Run("type annotation needed, nested empty array", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+              access(all) let foo: {Int: [String]} = {1: []}
+            `,
+			lint.RedundantTypeAnnotationAnalyzer,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic(nil),
+			diagnostics,
+		)
+	})
 }


### PR DESCRIPTION

## Description

The redundant type annotation analyzer incorrectly reported type annotations as unnecessary for expressions containing nested empty array/dictionary literals (e.g. `let foo: {Int: {String: AnyStruct}} = {1: {}}`).

The redundancy check already handled top-level empty literals, expand the fix to nested empty literals.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
