### PR TITLE
[lint] Add a new analyzer which suggests removing redundant parens in if/while statements

### DIFF
--- a/lint/redundant_parens_analyzer.go
+++ b/lint/redundant_parens_analyzer.go
@@ -1,0 +1,171 @@
+/*
+ * Cadence lint - The Cadence linter
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lint
+
+import (
+	"github.com/onflow/cadence/ast"
+	"github.com/onflow/cadence/tools/analysis"
+)
+
+var RedundantParensAnalyzer = (func() *analysis.Analyzer {
+
+	elementFilter := []ast.Element{
+		(*ast.IfStatement)(nil),
+		(*ast.WhileStatement)(nil),
+	}
+
+	return &analysis.Analyzer{
+		Description: "Detects unnecessary parentheses around conditions in if and while statements",
+		Requires: []*analysis.Analyzer{
+			analysis.InspectorAnalyzer,
+		},
+		Run: func(pass *analysis.Pass) interface{} {
+			inspector := pass.ResultOf[analysis.InspectorAnalyzer].(*ast.Inspector)
+
+			program := pass.Program
+			location := program.Location
+			code := program.Code
+			codeStr := string(code)
+			report := pass.Report
+
+			inspector.Preorder(
+				elementFilter,
+				func(element ast.Element) {
+
+					var keywordEndOffset int
+					var blockStartOffset int
+					var testStartPos, testEndPos ast.Position
+
+					switch stmt := element.(type) {
+					case *ast.IfStatement:
+						keywordEndOffset = stmt.StartPos.Offset + len("if")
+						blockStartOffset = stmt.Then.StartPosition().Offset
+						testStartPos = stmt.Test.StartPosition()
+						testEndPos = stmt.Test.EndPosition(nil)
+					case *ast.WhileStatement:
+						keywordEndOffset = stmt.StartPos.Offset + len("while")
+						blockStartOffset = stmt.Block.StartPosition().Offset
+						testStartPos = stmt.Test.StartPosition()
+						testEndPos = stmt.Test.EndPosition(nil)
+					default:
+						return
+					}
+
+					if keywordEndOffset >= blockStartOffset ||
+						blockStartOffset > len(code) {
+						return
+					}
+
+					region := code[keywordEndOffset:blockStartOffset]
+
+					// Find first and last non-whitespace byte in the region
+					firstNonWS := -1
+					lastNonWS := -1
+					for i, b := range region {
+						if b != ' ' && b != '\t' && b != '\n' && b != '\r' {
+							if firstNonWS == -1 {
+								firstNonWS = i
+							}
+							lastNonWS = i
+						}
+					}
+
+					if firstNonWS == -1 ||
+						region[firstNonWS] != '(' ||
+						region[lastNonWS] != ')' {
+						return
+					}
+
+					// Verify the opening '(' matches the closing ')'
+					// by counting balanced parentheses
+					depth := 0
+					for i := firstNonWS; i <= lastNonWS; i++ {
+						switch region[i] {
+						case '(':
+							depth++
+						case ')':
+							depth--
+							if depth == 0 && i != lastNonWS {
+								// The opening '(' closed before the last ')',
+								// so they are not wrapping the entire condition
+								return
+							}
+						}
+					}
+					if depth != 0 {
+						return
+					}
+
+					openParenOffset := keywordEndOffset + firstNonWS
+					closeParenOffset := keywordEndOffset + lastNonWS
+
+					openParenPos := ast.NewPositionAtCodeOffset(nil, codeStr, openParenOffset)
+					closeParenPos := ast.NewPositionAtCodeOffset(nil, codeStr, closeParenOffset)
+
+					diagnosticRange := ast.Range{
+						StartPos: openParenPos,
+						EndPos:   closeParenPos,
+					}
+
+					// Fix: remove '(' and any whitespace up to the expression,
+					// and remove ')' and any whitespace from the expression end
+					removeOpenRange := ast.Range{
+						StartPos: openParenPos,
+						EndPos:   testStartPos.Shifted(nil, -1),
+					}
+					removeCloseRange := ast.Range{
+						StartPos: testEndPos.Shifted(nil, 1),
+						EndPos:   closeParenPos,
+					}
+
+					report(analysis.Diagnostic{
+						Location: location,
+						Range:    diagnosticRange,
+						Category: ReplacementCategory,
+						Message:  "unnecessary parentheses around condition",
+						SuggestedFixes: []analysis.SuggestedFix{
+							{
+								Message: "Remove parentheses",
+								TextEdits: []ast.TextEdit{
+									{
+										Range:       removeOpenRange,
+										Replacement: "",
+									},
+									{
+										Range:       removeCloseRange,
+										Replacement: "",
+									},
+								},
+							},
+						},
+					})
+				},
+			)
+
+			return nil
+		},
+	}
+})()
+
+func init() {
+	RegisterAnalyzer(
+		"redundant-parens",
+		RedundantParensAnalyzer,
+	)
+}

--- a/lint/redundant_parens_analyzer_test.go
+++ b/lint/redundant_parens_analyzer_test.go
@@ -1,0 +1,271 @@
+/*
+ * Cadence lint - The Cadence linter
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lint_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/ast"
+	"github.com/onflow/cadence/tools/analysis"
+
+	"github.com/onflow/cadence-tools/lint"
+)
+
+func TestRedundantParensAnalyzer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("if with redundant parens", func(t *testing.T) {
+		t.Parallel()
+
+		code := `
+			access(all) contract Test {
+				access(all) fun test() {
+					if (true) {}
+				}
+			}
+			`
+
+		diagnostics := testAnalyzers(t,
+			code,
+			lint.RedundantParensAnalyzer,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic{
+				{
+					Location: testLocation,
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 69, Line: 4, Column: 8},
+						EndPos:   ast.Position{Offset: 74, Line: 4, Column: 13},
+					},
+					Category: lint.ReplacementCategory,
+					Message:  "unnecessary parentheses around condition",
+					SuggestedFixes: []analysis.SuggestedFix{
+						{
+							Message: "Remove parentheses",
+							TextEdits: []ast.TextEdit{
+								{
+									Range: ast.Range{
+										StartPos: ast.Position{Offset: 69, Line: 4, Column: 8},
+										EndPos:   ast.Position{Offset: 69, Line: 4, Column: 8},
+									},
+									Replacement: "",
+								},
+								{
+									Range: ast.Range{
+										StartPos: ast.Position{Offset: 74, Line: 4, Column: 13},
+										EndPos:   ast.Position{Offset: 74, Line: 4, Column: 13},
+									},
+									Replacement: "",
+								},
+							},
+						},
+					},
+				},
+			},
+			diagnostics,
+		)
+
+		// Apply fixes in reverse order so offsets stay valid
+		fixedCode := diagnostics[0].SuggestedFixes[0].TextEdits[1].ApplyTo(code)
+		fixedCode = diagnostics[0].SuggestedFixes[0].TextEdits[0].ApplyTo(fixedCode)
+
+		expectedFixedCode := `
+			access(all) contract Test {
+				access(all) fun test() {
+					if true {}
+				}
+			}
+			`
+
+		require.Equal(t, expectedFixedCode, fixedCode)
+	})
+
+	t.Run("if without parens", func(t *testing.T) {
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+			access(all) contract Test {
+				access(all) fun test() {
+					if true {}
+				}
+			}
+			`,
+			lint.RedundantParensAnalyzer,
+		)
+
+		require.Equal(t, []analysis.Diagnostic(nil), diagnostics)
+	})
+
+	t.Run("while with redundant parens", func(t *testing.T) {
+		t.Parallel()
+
+		code := `
+			access(all) contract Test {
+				access(all) fun test() {
+					while (true) {}
+				}
+			}
+			`
+
+		diagnostics := testAnalyzers(t,
+			code,
+			lint.RedundantParensAnalyzer,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic{
+				{
+					Location: testLocation,
+					Range: ast.Range{
+						StartPos: ast.Position{Offset: 72, Line: 4, Column: 11},
+						EndPos:   ast.Position{Offset: 77, Line: 4, Column: 16},
+					},
+					Category: lint.ReplacementCategory,
+					Message:  "unnecessary parentheses around condition",
+					SuggestedFixes: []analysis.SuggestedFix{
+						{
+							Message: "Remove parentheses",
+							TextEdits: []ast.TextEdit{
+								{
+									Range: ast.Range{
+										StartPos: ast.Position{Offset: 72, Line: 4, Column: 11},
+										EndPos:   ast.Position{Offset: 72, Line: 4, Column: 11},
+									},
+									Replacement: "",
+								},
+								{
+									Range: ast.Range{
+										StartPos: ast.Position{Offset: 77, Line: 4, Column: 16},
+										EndPos:   ast.Position{Offset: 77, Line: 4, Column: 16},
+									},
+									Replacement: "",
+								},
+							},
+						},
+					},
+				},
+			},
+			diagnostics,
+		)
+
+		fixedCode := diagnostics[0].SuggestedFixes[0].TextEdits[1].ApplyTo(code)
+		fixedCode = diagnostics[0].SuggestedFixes[0].TextEdits[0].ApplyTo(fixedCode)
+
+		expectedFixedCode := `
+			access(all) contract Test {
+				access(all) fun test() {
+					while true {}
+				}
+			}
+			`
+
+		require.Equal(t, expectedFixedCode, fixedCode)
+	})
+
+	t.Run("while without parens", func(t *testing.T) {
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+			access(all) contract Test {
+				access(all) fun test() {
+					while true {}
+				}
+			}
+			`,
+			lint.RedundantParensAnalyzer,
+		)
+
+		require.Equal(t, []analysis.Diagnostic(nil), diagnostics)
+	})
+
+	t.Run("if with binary expression in parens", func(t *testing.T) {
+		t.Parallel()
+
+		code := `
+			access(all) contract Test {
+				access(all) fun test() {
+					if (1 == 1) {}
+				}
+			}
+			`
+
+		diagnostics := testAnalyzers(t,
+			code,
+			lint.RedundantParensAnalyzer,
+		)
+
+		require.Equal(t, 1, len(diagnostics))
+		require.Equal(t, "unnecessary parentheses around condition", diagnostics[0].Message)
+
+		fixedCode := diagnostics[0].SuggestedFixes[0].TextEdits[1].ApplyTo(code)
+		fixedCode = diagnostics[0].SuggestedFixes[0].TextEdits[0].ApplyTo(fixedCode)
+
+		expectedFixedCode := `
+			access(all) contract Test {
+				access(all) fun test() {
+					if 1 == 1 {}
+				}
+			}
+			`
+
+		require.Equal(t, expectedFixedCode, fixedCode)
+	})
+
+	t.Run("if with sub-expression parens only", func(t *testing.T) {
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+			access(all) contract Test {
+				access(all) fun test() {
+					if (1 == 1) && (2 == 2) {}
+				}
+			}
+			`,
+			lint.RedundantParensAnalyzer,
+		)
+
+		require.Equal(t, []analysis.Diagnostic(nil), diagnostics)
+	})
+
+	t.Run("if let (optional binding)", func(t *testing.T) {
+		t.Parallel()
+
+		diagnostics := testAnalyzers(t,
+			`
+			access(all) contract Test {
+				access(all) fun test() {
+					let x: Int? = 1
+					if let y = x {}
+				}
+			}
+			`,
+			lint.RedundantParensAnalyzer,
+		)
+
+		require.Equal(t, []analysis.Diagnostic(nil), diagnostics)
+	})
+}


### PR DESCRIPTION
## Description

Tested expressions in `if`/`while` statements do not need to be wrapped in parentheses like in some other languages.

Detect some cases and suggest removing the unnecessary parentheses.

The analyzer does not detect all cases, e.g. when the tested expression contains strings or comments with parentheses, but it also does not report false positives.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
