### PR TITLE
[test] fix Reset panicking when height equals current

### DIFF
--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -820,18 +820,31 @@ func (e *EmulatorBackend) StandardLibraryHandler() stdlib.StandardLibraryHandler
 }
 
 func (e *EmulatorBackend) Reset(height uint64) {
-	err := e.blockchain.RollbackToBlockHeight(height)
+	latestBlock, err := e.blockchain.GetLatestBlock()
 	if err != nil {
 		panic(err)
+	}
+
+	if height == latestBlock.Height {
+		err = e.blockchain.ResetPendingBlock()
+		if err != nil {
+			panic(err)
+		}
+		return
 	}
 
 	// Reset the transaction offset.
 	e.blockOffset = 0
 
+	err = e.blockchain.RollbackToBlockHeight(height)
+	if err != nil {
+		panic(err)
+	}
+
 	// Sync the clock to the rolled-back block's timestamp so that subsequent
 	// blocks continue from that point in time rather than snapping back to the
 	// wall-clock offset that was in effect before the rollback.
-	latestBlock, err := e.blockchain.GetLatestBlock()
+	latestBlock, err = e.blockchain.GetLatestBlock()
 	if err != nil {
 		panic(err)
 	}

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -5489,6 +5489,87 @@ func TestBlockchainReset(t *testing.T) {
 	require.NoError(t, result.Error)
 }
 
+func TestBlockchainResetToCurrentHeight(t *testing.T) {
+	t.Parallel()
+
+	const testCode = `
+        import Test
+
+        access(all)
+        fun testBlockchainResetToCurrentHeight() {
+            let height = getCurrentBlock().height
+			Test.reset(to: height)
+            Test.assertEqual(height, getCurrentBlock().height)
+        }
+	`
+
+	runner := NewTestRunner()
+
+	result, err := runner.RunTest(testCode, "testBlockchainResetToCurrentHeight")
+	require.NoError(t, err)
+	require.NoError(t, result.Error)
+}
+
+func TestBlockchainResetToCurrentHeightWithPendingTransaction(t *testing.T) {
+	t.Parallel()
+
+	const testCode = `
+        import Test
+        import BlockchainHelpers
+
+        access(all)
+        fun testBlockchainResetToCurrentHeightWithPendingTransaction() {
+            let account = Test.createAccount()
+            var balance = getFlowBalance(account: account)
+            Test.assertEqual(0.0, balance)
+
+            let height = getCurrentBlockHeight()
+
+            // Queue a mint transaction but do NOT execute it
+            let code = Test.readFile("\u{0}helper/mint_flow.cdc")
+            let tx = Test.Transaction(
+                code: code,
+                authorizers: [Test.serviceAccount().address],
+                signers: [],
+                arguments: [account.address, 1500.0]
+            )
+            Test.addTransaction(tx)
+
+            // pending transaction must be discarded
+            Test.reset(to: height)
+			Test.executeNextTransaction()
+            Test.commitBlock()
+
+            // balance unchanged (mint never ran), only one empty block committed
+            balance = getFlowBalance(account: account)
+            Test.assertEqual(0.0, balance)
+            Test.assertEqual(getCurrentBlockHeight(), height + 1)
+
+			Test.reset(to: height)
+
+			// Queue a mint transaction execute it but don't commit it
+            Test.addTransaction(tx)
+			Test.executeNextTransaction()
+
+            // pending transaction must be discarded
+            Test.reset(to: height)
+			Test.executeNextTransaction()
+            Test.commitBlock()
+
+            // balance unchanged (mint never ran), only one empty block committed
+            balance = getFlowBalance(account: account)
+            Test.assertEqual(0.0, balance)
+            Test.assertEqual(getCurrentBlockHeight(), height + 1)
+        }
+	`
+
+	runner := NewTestRunner()
+
+	result, err := runner.RunTest(testCode, "testBlockchainResetToCurrentHeightWithPendingTransaction")
+	require.NoError(t, err)
+	require.NoError(t, result.Error)
+}
+
 func TestBlockchainResetPersistsTimeRollback(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`Reset` would panic when called with the current block height. The fix fetches the latest block before attempting a rollback:
if the requested height matches, it calls `ReloadBlockchain()` instead, which flushes the emulator's pending block (discarding any queued-but-unexecuted transactions) without touching committed state. 
A real rollback proceeds unchanged for any height below current.

This makes it possible to simply call Reset instead of having to wrap it in every Test:
```cadence
access(all)
fun safeReset() {
    let cur = getCurrentBlockHeight()
    if cur > snapshot {
        Test.reset(to: snapshot)
    }
}
```