### PR TITLE
[lint] Skip hardcoded address analyzer for test files

### DIFF
--- a/lint/hardcoded_address_analyzer.go
+++ b/lint/hardcoded_address_analyzer.go
@@ -19,7 +19,10 @@
 package lint
 
 import (
+	"strings"
+
 	"github.com/onflow/cadence/ast"
+	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/sema"
 	"github.com/onflow/cadence/tools/analysis"
 )
@@ -39,10 +42,18 @@ var HardcodedAddressAnalyzer = (func() *analysis.Analyzer {
 			analysis.InspectorAnalyzer,
 		},
 		Run: func(pass *analysis.Pass) interface{} {
-			inspector := pass.ResultOf[analysis.InspectorAnalyzer].(*ast.Inspector)
-
 			program := pass.Program
 			location := program.Location
+
+			// Skip test files — hardcoded addresses are expected in tests.
+			if stringLoc, ok := location.(common.StringLocation); ok {
+				if strings.HasSuffix(string(stringLoc), "_test.cdc") {
+					return nil
+				}
+			}
+
+			inspector := pass.ResultOf[analysis.InspectorAnalyzer].(*ast.Inspector)
+
 			elaboration := program.Checker.Elaboration
 			report := pass.Report
 

--- a/lint/hardcoded_address_analyzer_test.go
+++ b/lint/hardcoded_address_analyzer_test.go
@@ -22,11 +22,42 @@ import (
 	"testing"
 
 	"github.com/onflow/cadence/ast"
+	"github.com/onflow/cadence/common"
 	"github.com/onflow/cadence/tools/analysis"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/cadence-tools/lint"
 )
+
+func testAnalyzersWithLocation(
+	t *testing.T,
+	location common.Location,
+	code string,
+	analyzers ...*analysis.Analyzer,
+) []analysis.Diagnostic {
+	config := analysis.NewSimpleConfig(
+		lint.LoadMode,
+		map[common.Location][]byte{
+			location: []byte(code),
+		},
+		nil,
+		nil,
+	)
+
+	programs, err := analysis.Load(config, location)
+	require.NoError(t, err)
+
+	var diagnostics []analysis.Diagnostic
+
+	programs.Get(location).Run(
+		analyzers,
+		func(diagnostic analysis.Diagnostic) {
+			diagnostics = append(diagnostics, diagnostic)
+		},
+	)
+
+	return diagnostics
+}
 
 func TestHardcodedAddressAnalyzer(t *testing.T) {
 
@@ -182,6 +213,27 @@ func TestHardcodedAddressAnalyzer(t *testing.T) {
 					},
 				},
 			},
+			diagnostics,
+		)
+	})
+
+	t.Run("hardcoded address in test file not flagged", func(t *testing.T) {
+
+		t.Parallel()
+
+		diagnostics := testAnalyzersWithLocation(t,
+			common.StringLocation("my_contract_test.cdc"),
+			`
+                access(all) fun main() {
+                    let addr: Address = 0x1234567890abcdef
+                }
+            `,
+			lint.HardcodedAddressAnalyzer,
+		)
+
+		require.Equal(
+			t,
+			[]analysis.Diagnostic(nil),
 			diagnostics,
 		)
 	})


### PR DESCRIPTION
## Summary
- The hardcoded address analyzer now skips files ending in `_test.cdc`, since hardcoded addresses are expected in test code.
- Adds a test case verifying the analyzer produces no diagnostics for test file locations.

## Test plan
- [x] Existing tests pass (`TestHardcodedAddressAnalyzer`)
- [x] New test case: `hardcoded_address_in_test_file_not_flagged` verifies address literals in `_test.cdc` files are not reported