### PR TITLE
[test] Return parsing errors from `replaceImports` instead of panicking

### DIFF
--- a/test/emulator_backend.go
+++ b/test/emulator_backend.go
@@ -518,7 +518,11 @@ func (e *EmulatorBackend) RunScript(
 		arguments = append(arguments, encodedArg)
 	}
 
-	code = e.replaceImports(code)
+	var replaceErr error
+	code, replaceErr = e.replaceImports(code)
+	if replaceErr != nil {
+		return &stdlib.ScriptResult{Error: replaceErr}
+	}
 
 	result, err := e.blockchain.ExecuteScript([]byte(code), arguments)
 	if err != nil {
@@ -658,7 +662,11 @@ func (e *EmulatorBackend) AddTransaction(
 	signers []*stdlib.Account,
 	args []interpreter.Value,
 ) error {
-	code = e.replaceImports(code)
+	var err error
+	code, err = e.replaceImports(code)
+	if err != nil {
+		return err
+	}
 
 	tx := e.newTransaction(code, authorizers)
 
@@ -674,7 +682,7 @@ func (e *EmulatorBackend) AddTransaction(
 		}
 	}
 
-	err := e.signTransaction(tx, signers)
+	err = e.signTransaction(tx, signers)
 	if err != nil {
 		return err
 	}
@@ -750,7 +758,10 @@ func (e *EmulatorBackend) DeployContract(
 	if err != nil {
 		panic(err)
 	}
-	code = e.replaceImports(code)
+	code, err = e.replaceImports(code)
+	if err != nil {
+		return fmt.Errorf("failed to parse contract %q: %w", name, err)
+	}
 
 	hexEncodedCode := hex.EncodeToString([]byte(code))
 
@@ -1097,10 +1108,10 @@ func (e *EmulatorBackend) signTransaction(
 	return nil
 }
 
-func (e *EmulatorBackend) replaceImports(code string) string {
+func (e *EmulatorBackend) replaceImports(code string) (string, error) {
 	program, err := parser.ParseProgram(nil, []byte(code), parser.Config{})
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 
 	sb := strings.Builder{}
@@ -1160,7 +1171,7 @@ func (e *EmulatorBackend) replaceImports(code string) string {
 
 	sb.WriteString(code[importDeclEnd:])
 
-	return sb.String()
+	return sb.String(), nil
 }
 
 // wrapWithBuiltins wraps a user-provided resolver with fallback to built-in contracts.

--- a/test/test_framework_test.go
+++ b/test/test_framework_test.go
@@ -3816,7 +3816,8 @@ func TestReplaceImports(t *testing.T) {
         fun main() {}
 	`
 
-	replacedCode := emulatorBackend.replaceImports(code)
+	replacedCode, err := emulatorBackend.replaceImports(code)
+	require.NoError(t, err)
 
 	assert.Equal(t, expected, replacedCode)
 }

--- a/test/test_runner.go
+++ b/test/test_runner.go
@@ -425,7 +425,7 @@ func (r *TestRunner) GetTests(script string) ([]string, error) {
 	return tests, nil
 }
 
-func (r *TestRunner) replaceImports(code string) string {
+func (r *TestRunner) replaceImports(code string) (string, error) {
 	return r.backend.replaceImports(code)
 }
 
@@ -541,7 +541,10 @@ func (r *TestRunner) parseCheckAndInterpret(script string) (
 		}
 	}
 
-	script = r.replaceImports(script)
+	script, err = r.replaceImports(script)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	program, err := env.ParseAndCheckProgram([]byte(script), ctx.Location, false)
 	if err != nil {
@@ -952,7 +955,10 @@ func (r *TestRunner) parseAndCheckImport(
 
 	setupEVMEnvironment(r.backend.chain, fvmEnv, env)
 
-	code = r.replaceImports(code)
+	code, err = r.replaceImports(code)
+	if err != nil {
+		return nil, nil, err
+	}
 	program, err := r.testRuntime.ParseAndCheckProgram([]byte(code), ctx)
 
 	if err != nil {


### PR DESCRIPTION
## Problem

`EmulatorBackend.replaceImports` called `parser.ParseProgram` and panicked on any parse failure. When a contract used a reserved keyword as an identifier (e.g. `create` as a function name), that panic was caught by `interpreter.RecoverErrors`, wrapped with a full Go stack trace via `NewUnexpectedErrorFromCause`, and surfaced to the CLI as hundreds of goroutine frames instead of a clean error message.

The same panic path was reachable from every call site: `DeployContract` (which also silently discarded the error return), `AddTransaction`, `RunScript`, and `TestRunner.parseCheckAndInterpret` / `parseAndCheckImport`.

## Fix

Changed `replaceImports` from `string` to `(string, error)` and replaced `panic(err)` with `return "", err`. Updated every call site to propagate the error normally. `DeployContract` wraps it with `failed to parse contract %q: %w` so the contract name appears in the message; all other callers return it directly.

After this fix a bad contract produces a clean diagnostic:

```
failed to parse contract "Swapper": expected identifier after start of function declaration, got keyword create --> :31:20
```
