### PR TITLE
[LS] Improve hover and go-to-definition for types and members

### DIFF
--- a/languageserver/integration/config_manager.go
+++ b/languageserver/integration/config_manager.go
@@ -19,7 +19,6 @@
 package integration
 
 import (
-	"encoding/json"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -327,33 +326,35 @@ func (m *ConfigManager) IsSameProject(projectID string, absPath string) bool {
 	return absDst == cfgPath
 }
 
-// GetContractSourceForProject reads the project's flow.json and returns the code for the given contract name if mapped
+// GetContractSourceForProject reads the project's flow.json and returns the code
+// for the given contract name if mapped
 func (m *ConfigManager) GetContractSourceForProject(projectID string, name string) (string, error) {
-	cfgPath := m.ConfigPathForProject(projectID)
-	if cfgPath == "" || name == "" {
-		return "", nil
-	}
-	data, err := m.loader.ReadFile(cfgPath)
-	if err != nil {
+	path, err := m.GetContractPathForProject(projectID, name)
+	if err != nil || path == "" {
 		return "", err
 	}
-	var parsed struct {
-		Contracts map[string]string `json:"contracts"`
-	}
-	if err := json.Unmarshal(data, &parsed); err != nil {
-		return "", err
-	}
-	rel, ok := parsed.Contracts[name]
-	if !ok || rel == "" {
-		return "", nil
-	}
-	dir := filepath.Dir(cfgPath)
-	path := filepath.Join(dir, rel)
+
 	code, err := m.loader.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
+
 	return string(code), nil
+}
+
+// GetContractPathForProject reads the project's flow.json and returns the absolute on-disk path
+// for the given contract name if mapped
+func (m *ConfigManager) GetContractPathForProject(projectID string, name string) (string, error) {
+	if name == "" {
+		return "", nil
+	}
+
+	st, err := m.ResolveStateForProject(projectID)
+	if err != nil || st == nil {
+		return "", err
+	}
+
+	return st.GetPathByName(name)
 }
 
 // ResolveStateForProject returns the state associated with the given project ID (flow.json path)

--- a/languageserver/integration/config_manager.go
+++ b/languageserver/integration/config_manager.go
@@ -19,6 +19,7 @@
 package integration
 
 import (
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -326,19 +327,37 @@ func (m *ConfigManager) IsSameProject(projectID string, absPath string) bool {
 	return absDst == cfgPath
 }
 
-// GetContractSourceForProject reads the project's flow.json and returns the code
-// for the given contract name if mapped
+// GetContractSourceForProject reads the project's flow.json and returns the
+// code for the given contract name if mapped. This is a flowkit-independent
+// fallback used by resolveStringIdentifierImport when flowkit fails to load
+// the project state (e.g. because the flow.json has inconsistencies flowkit
+// rejects). It only handles the simple `"Contract": "./path.cdc"` shape; the
+// verbose shape is the flowkit path's responsibility.
 func (m *ConfigManager) GetContractSourceForProject(projectID string, name string) (string, error) {
-	path, err := m.GetContractPathForProject(projectID, name)
-	if err != nil || path == "" {
+	cfgPath := m.ConfigPathForProject(projectID)
+	if cfgPath == "" || name == "" {
+		return "", nil
+	}
+	data, err := m.loader.ReadFile(cfgPath)
+	if err != nil {
 		return "", err
 	}
-
+	var parsed struct {
+		Contracts map[string]string `json:"contracts"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return "", err
+	}
+	rel, ok := parsed.Contracts[name]
+	if !ok || rel == "" {
+		return "", nil
+	}
+	dir := filepath.Dir(cfgPath)
+	path := filepath.Join(dir, rel)
 	code, err := m.loader.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
-
 	return string(code), nil
 }
 

--- a/languageserver/integration/integration.go
+++ b/languageserver/integration/integration.go
@@ -173,6 +173,7 @@ func NewFlowIntegration(s *server.Server, enableFlowClient bool) (*FlowIntegrati
 	options := []server.Option{
 		server.WithDiagnosticProvider(diagnostics),
 		server.WithStringImportResolver(resolve.stringImport),
+		server.WithLocationToURIResolver(resolve.locationToURI),
 		server.WithInitializationOptionsHandler(integration.initialize),
 		server.WithExtendedStandardLibraryValues(FVMStandardLibraryValues()...),
 		server.WithIdentifierImportResolver(resolve.identifierImportProject),

--- a/languageserver/integration/mock_state_test.go
+++ b/languageserver/integration/mock_state_test.go
@@ -33,6 +33,27 @@ func (_m *mockFlowState) GetCodeByName(name string) (string, error) {
 	return r0, r1
 }
 
+// GetPathByName provides a mock function with given fields: name
+func (_m *mockFlowState) GetPathByName(name string) (string, error) {
+	ret := _m.Called(name)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(name)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // IsLoaded provides a mock function with given fields:
 func (_m *mockFlowState) IsLoaded() bool {
 	ret := _m.Called()

--- a/languageserver/integration/resolvers.go
+++ b/languageserver/integration/resolvers.go
@@ -33,6 +33,8 @@ import (
 	"github.com/onflow/flowkit/v2"
 
 	coreContracts "github.com/onflow/flow-core-contracts/lib/go/contracts"
+
+	"github.com/onflow/cadence-tools/languageserver/protocol"
 )
 
 // networkContractMap maps network name -> contract name -> address
@@ -144,6 +146,51 @@ func (r *resolvers) addressImport(projectID string, location common.AddressLocat
 	}
 
 	return string(account.Contracts[location.Name]), nil
+}
+
+// locationToURI maps a common.Location to the document URI of its on-disk source,
+// when one is knowable from project state. Used by e.g. cross-file go-to-definition.
+// Returns "" if the location isn't file backed (e.g. address locations resolved over the network).
+func (r *resolvers) locationToURI(projectID string, location common.Location) protocol.DocumentURI {
+	if r.cfgManager == nil {
+		return ""
+	}
+
+	stringLoc, ok := location.(common.StringLocation)
+	if !ok {
+		return ""
+	}
+
+	name := string(stringLoc)
+	if isContractName(name) {
+		path, err := r.cfgManager.GetContractPathForProject(projectID, name)
+		if err != nil || path == "" {
+			return ""
+		}
+		return pathToURI(path)
+	}
+
+	// File-style import (`import "./Foo.cdc"`) resolved relative to the project root by resolveFileImport above.
+	filename := deURI(cleanWindowsPath(name))
+	if filepath.IsAbs(filename) {
+		return pathToURI(filename)
+	}
+
+	if projectID != "" {
+		if cfg := r.cfgManager.ConfigPathForProject(projectID); cfg != "" {
+			return pathToURI(filepath.Join(filepath.Dir(cfg), filename))
+		}
+	}
+
+	return ""
+}
+
+func pathToURI(path string) protocol.DocumentURI {
+	if path == "" {
+		return ""
+	}
+
+	return protocol.DocumentURI("file://" + path)
 }
 
 // identifierImport resolves the code for an identifier location.

--- a/languageserver/integration/resolvers_test.go
+++ b/languageserver/integration/resolvers_test.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/onflow/cadence-tools/languageserver/protocol"
 )
 
 func Test_FileImport(t *testing.T) {
@@ -145,6 +147,11 @@ func Test_SimpleImport(t *testing.T) {
 		resolved, err := resolver.stringImport("/p/flow.json", common.StringLocation("Foo"))
 		assert.Error(t, err)
 		assert.Empty(t, resolved)
+	})
+
+	t.Run("locationToURI resolves identifier import to file URI", func(t *testing.T) {
+		uri := resolver.locationToURI("/p/flow.json", common.StringLocation("Test"))
+		assert.Equal(t, protocol.DocumentURI("file:///p/test.cdc"), uri)
 	})
 }
 

--- a/languageserver/integration/state.go
+++ b/languageserver/integration/state.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/onflow/flowkit/v2"
+	"github.com/onflow/flowkit/v2/config"
 )
 
 //go:generate go run github.com/vektra/mockery/cmd/mockery --name flowState --filename mock_state_test.go --inpkg
@@ -30,6 +31,7 @@ type flowState interface {
 	Load(configPath string) error
 	Reload() error
 	GetCodeByName(name string) (string, error)
+	GetPathByName(name string) (string, error)
 	IsLoaded() bool
 	getConfigPath() string
 	getState() *flowkit.State
@@ -67,21 +69,34 @@ func (s *flowkitState) Reload() error {
 	return s.Load(s.configPath)
 }
 
-func (s *flowkitState) GetCodeByName(name string) (string, error) {
+// GetContract returns the contract configuration for the given contract identifier,
+// resolved through the project's flow.json contract mapping.
+func (s *flowkitState) GetContract(name string) (*config.Contract, error) {
 	// Check if the state is initialized
 	if !s.IsLoaded() {
-		return "", fmt.Errorf("state is not initialized")
+		return nil, fmt.Errorf("state is not initialized")
 	}
 
 	// Try to find the contract by name
 	contract, err := s.state.Contracts().ByName(name)
 	if err != nil {
-		return "", fmt.Errorf("couldn't find the contract by import identifier: %s", name)
+		return nil, fmt.Errorf("couldn't find the contract by import identifier: %s", name)
 	}
 
 	// If no location is set, return an error
 	if contract.Location == "" {
-		return "", fmt.Errorf("source file could not be found for import identifier: %s", name)
+		return nil, fmt.Errorf("source file could not be found for import identifier: %s", name)
+	}
+
+	return contract, nil
+}
+
+// GetCodeByName returns the source code of the contract with the given identifier,
+// resolved through the project's flow.json contract mapping.
+func (s *flowkitState) GetCodeByName(name string) (string, error) {
+	contract, err := s.GetContract(name)
+	if err != nil {
+		return "", err
 	}
 
 	// Resolve the contract source code from file location
@@ -89,7 +104,20 @@ func (s *flowkitState) GetCodeByName(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return code, nil
+}
+
+// GetPathByName returns the absolute on-disk path of the source file for the given contract identifier,
+// resolved through the project's flow.json contract mapping.
+func (s *flowkitState) GetPathByName(name string) (string, error) {
+	contract, err := s.GetContract(name)
+	if err != nil {
+		return "", err
+	}
+
+	// Resolve the contract source file path from file location
+	return filepath.Join(filepath.Dir(s.configPath), contract.Location), nil
 }
 
 func (s *flowkitState) IsLoaded() bool {

--- a/languageserver/server/definition_test.go
+++ b/languageserver/server/definition_test.go
@@ -1,0 +1,112 @@
+/*
+ * Cadence languageserver - The Cadence language server
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/onflow/cadence/common"
+
+	"github.com/onflow/cadence-tools/languageserver/protocol"
+)
+
+func TestDefinition(t *testing.T) {
+	t.Parallel()
+
+	const fooCode = `
+      access(all) contract Foo {
+          access(all) struct S {}
+      }
+    `
+
+	const counterCode = `
+      import "Foo"
+      access(all) contract Counter {
+          access(all) fun foo(_ : Foo.S) {}
+      }
+    `
+
+	server, err := NewServer()
+	require.NoError(t, err)
+
+	const fooURI = protocol.DocumentURI("file:///Foobar/cadence/contracts/Foo.cdc")
+
+	err = server.SetOptions(
+		WithStringImportResolver(
+			func(_ string, location common.StringLocation) (string, error) {
+				if location == "Foo" {
+					return fooCode, nil
+				}
+				return "", nil
+			},
+		),
+		WithLocationToURIResolver(
+			func(_ string, location common.Location) protocol.DocumentURI {
+				if loc, ok := location.(common.StringLocation); ok && loc == "Foo" {
+					return fooURI
+				}
+				return ""
+			},
+		),
+	)
+	require.NoError(t, err)
+
+	server.projectIdentity = staticProjectIdentity("foobar")
+
+	counterURI := protocol.DocumentURI("file:///Foobar/cadence/contracts/Counter.cdc")
+	_, err = server.getDiagnostics(counterURI, counterCode, 1, func(*protocol.LogMessageParams) {})
+	require.NoError(t, err)
+
+	fooLoc, err := server.Definition(nil, &protocol.TextDocumentPositionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: counterURI},
+		Position:     protocol.Position{Line: 3, Character: 34},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		&protocol.Location{
+			URI: fooURI,
+			Range: protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 27},
+				End:   protocol.Position{Line: 1, Character: 30},
+			},
+		},
+		fooLoc,
+	)
+
+	sLoc, err := server.Definition(nil, &protocol.TextDocumentPositionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: counterURI},
+		Position:     protocol.Position{Line: 3, Character: 38},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		&protocol.Location{
+			URI: fooURI,
+			Range: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 29},
+				End:   protocol.Position{Line: 2, Character: 30},
+			},
+		},
+		sLoc,
+	)
+}

--- a/languageserver/server/definition_test.go
+++ b/languageserver/server/definition_test.go
@@ -76,11 +76,22 @@ func TestDefinition(t *testing.T) {
 	_, err = server.getDiagnostics(counterURI, counterCode, 1, func(*protocol.LogMessageParams) {})
 	require.NoError(t, err)
 
-	fooLoc, err := server.Definition(nil, &protocol.TextDocumentPositionParams{
-		TextDocument: protocol.TextDocumentIdentifier{URI: counterURI},
-		Position:     protocol.Position{Line: 3, Character: 34},
-	})
-	require.NoError(t, err)
+	getDefinition := func(line, character uint32) *protocol.Location {
+		t.Helper()
+
+		location, err := server.Definition(
+			nil,
+			&protocol.TextDocumentPositionParams{
+				TextDocument: protocol.TextDocumentIdentifier{URI: counterURI},
+				Position: protocol.Position{
+					Line:      line,
+					Character: character,
+				},
+			},
+		)
+		require.NoError(t, err)
+		return location
+	}
 
 	assert.Equal(t,
 		&protocol.Location{
@@ -90,14 +101,8 @@ func TestDefinition(t *testing.T) {
 				End:   protocol.Position{Line: 1, Character: 30},
 			},
 		},
-		fooLoc,
+		getDefinition(3, 34),
 	)
-
-	sLoc, err := server.Definition(nil, &protocol.TextDocumentPositionParams{
-		TextDocument: protocol.TextDocumentIdentifier{URI: counterURI},
-		Position:     protocol.Position{Line: 3, Character: 38},
-	})
-	require.NoError(t, err)
 
 	assert.Equal(t,
 		&protocol.Location{
@@ -107,6 +112,150 @@ func TestDefinition(t *testing.T) {
 				End:   protocol.Position{Line: 2, Character: 30},
 			},
 		},
-		sLoc,
+		getDefinition(3, 38),
+	)
+}
+
+func TestDefinitionMemberImported(t *testing.T) {
+	t.Parallel()
+
+	const fooCode = `
+      access(all) contract Foo {
+          access(all) let a: Int
+
+          access(all) struct S {
+              access(all) fun foo() {}
+          }
+
+          init() {
+              self.a = 1
+          }
+      }
+    `
+
+	const counterCode = `
+      import "Foo"
+
+      access(all) contract Counter {
+          access(all) fun run() {
+              let a = Foo.a
+              let s = Foo.S()
+              s.foo()
+          }
+      }
+    `
+
+	server, err := NewServer()
+	require.NoError(t, err)
+
+	const fooURI = protocol.DocumentURI("file:///Foobar/cadence/contracts/Foo.cdc")
+
+	err = server.SetOptions(
+		WithStringImportResolver(func(_ string, location common.StringLocation) (string, error) {
+			if location == "Foo" {
+				return fooCode, nil
+			}
+			return "", nil
+		}),
+		WithLocationToURIResolver(func(_ string, location common.Location) protocol.DocumentURI {
+			if loc, ok := location.(common.StringLocation); ok && loc == "Foo" {
+				return fooURI
+			}
+			return ""
+		}),
+	)
+	require.NoError(t, err)
+
+	server.projectIdentity = staticProjectIdentity("foobar")
+
+	counterURI := protocol.DocumentURI("file:///Foobar/cadence/contracts/Counter.cdc")
+	_, err = server.getDiagnostics(counterURI, counterCode, 1, func(*protocol.LogMessageParams) {})
+	require.NoError(t, err)
+
+	getDefinition := func(line, character uint32) *protocol.Location {
+		t.Helper()
+
+		location, err := server.Definition(
+			nil,
+			&protocol.TextDocumentPositionParams{
+				TextDocument: protocol.TextDocumentIdentifier{URI: counterURI},
+				Position: protocol.Position{
+					Line:      line,
+					Character: character,
+				},
+			},
+		)
+		require.NoError(t, err)
+		return location
+	}
+
+	// `a` in `let a = Foo.a` on line 5
+	// =>
+	// `a` in `let a: Int` in Foo.cdc line 2
+	assert.Equal(t,
+		&protocol.Location{
+			URI: fooURI,
+			Range: protocol.Range{
+				Start: protocol.Position{Line: 2, Character: 26},
+				End:   protocol.Position{Line: 2, Character: 27},
+			},
+		},
+		getDefinition(5, 26),
+	)
+
+	// `foo` in `s.foo()` on line 7
+	// =>
+	// `foo` in `fun foo()` in Foo.cdc line 5
+	assert.Equal(t,
+		&protocol.Location{
+			URI: fooURI,
+			Range: protocol.Range{
+				Start: protocol.Position{Line: 5, Character: 30},
+				End:   protocol.Position{Line: 5, Character: 33},
+			},
+		},
+		getDefinition(7, 16),
+	)
+
+	// `Foo` in `let s = Foo.S()` on line 6
+	// =>
+	// `Foo` in `contract Foo` in Foo.cdc line 1
+	assert.Equal(t,
+		&protocol.Location{
+			URI: fooURI,
+			Range: protocol.Range{
+				Start: protocol.Position{Line: 1, Character: 27},
+				End:   protocol.Position{Line: 1, Character: 30},
+			},
+		},
+		getDefinition(6, 22),
+	)
+
+	// `s` in `let s = Foo.S()` on line 6
+	// =>
+	// `s` in `let s = Foo.S()` in Counter.cdc line 6
+	assert.Equal(t,
+		&protocol.Location{
+			URI: counterURI,
+			Range: protocol.Range{
+				Start: protocol.Position{Line: 6, Character: 18},
+				End:   protocol.Position{Line: 6, Character: 19},
+			},
+		},
+		getDefinition(6, 18),
+	)
+
+	// `s` in `s.foo()` on line 7
+	// =>
+	// `s` in `let s = Foo.S()` in Counter.cdc line 6
+	assert.Equal(t,
+		&protocol.Location{
+			URI: counterURI,
+			Range: protocol.Range{
+				Start: protocol.Position{Line: 6, Character: 18},
+				End:   protocol.Position{Line: 6, Character: 19},
+			},
+		},
+		getDefinition(7, 14),
 	)
 }

--- a/languageserver/server/hover_test.go
+++ b/languageserver/server/hover_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/onflow/cadence/common"
+
 	"github.com/onflow/cadence-tools/languageserver/protocol"
 )
 
@@ -67,5 +69,148 @@ func TestHover(t *testing.T) {
 			},
 		},
 		hover,
+	)
+}
+
+func TestHoverType(t *testing.T) {
+	t.Parallel()
+
+	server, err := NewServer()
+	require.NoError(t, err)
+
+	const code = `
+      /// docstring for A
+      access(all) contract A {
+
+          /// docstring for S
+          access(all) struct S {}
+
+          access(all) fun b(_ s: A.S) {}
+      }
+    `
+	uri := protocol.DocumentURI("file:///test.cdc")
+
+	_, err = server.getDiagnostics(uri, code, 1, func(*protocol.LogMessageParams) {})
+	require.NoError(t, err)
+
+	hoverA, err := server.Hover(
+		nil,
+		&protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+			Position:     protocol.Position{Line: 7, Character: 34},
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, hoverA)
+
+	assert.Equal(
+		t,
+		protocol.MarkupContent{
+			Kind:  protocol.Markdown,
+			Value: "**Type**\n\n```cadence\nA\n```\n\n**Documentation**\n\n docstring for A\n",
+		},
+		hoverA.Contents,
+	)
+
+	hoverS, err := server.Hover(
+		nil,
+		&protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+			Position:     protocol.Position{Line: 7, Character: 36},
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, hoverS)
+
+	assert.Equal(
+		t,
+		protocol.MarkupContent{
+			Kind:  protocol.Markdown,
+			Value: "**Type**\n\n```cadence\nA.S\n```\n\n**Documentation**\n\n docstring for S\n",
+		},
+		hoverS.Contents,
+	)
+}
+
+type staticProjectIdentity string
+
+func (s staticProjectIdentity) ProjectIDForURI(protocol.DocumentURI) string {
+	return string(s)
+}
+
+func TestHoverTypeImported(t *testing.T) {
+	t.Parallel()
+
+	const fooCode = `
+      /// docstring for Foo
+      access(all) contract Foo {
+          /// docstring for S
+          access(all) struct S {}
+      }
+    `
+
+	const counterCode = `
+      import "Foo"
+
+      access(all) contract Counter {
+          access(all) fun foo(_ : Foo.S) {}
+      }
+    `
+
+	server, err := NewServer()
+	require.NoError(t, err)
+
+	err = server.SetOptions(
+		WithStringImportResolver(
+			func(_ string, location common.StringLocation) (string, error) {
+				if location == "Foo" {
+					return fooCode, nil
+				}
+				return "", nil
+			},
+		),
+	)
+	require.NoError(t, err)
+
+	server.projectIdentity = staticProjectIdentity("foobar")
+
+	counterURI := protocol.DocumentURI("file:///Foobar/cadence/contracts/Counter.cdc")
+	_, err = server.getDiagnostics(counterURI, counterCode, 1, func(*protocol.LogMessageParams) {})
+	require.NoError(t, err)
+
+	hoverFoo, err := server.Hover(
+		nil,
+		&protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: counterURI},
+			Position:     protocol.Position{Line: 4, Character: 37},
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, hoverFoo)
+
+	assert.Equal(t,
+		protocol.MarkupContent{
+			Kind:  protocol.Markdown,
+			Value: "**Type**\n\n```cadence\nFoo\n```\n\n**Documentation**\n\n docstring for Foo\n",
+		},
+		hoverFoo.Contents,
+	)
+
+	hoverS, err := server.Hover(
+		nil,
+		&protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: counterURI},
+			Position:     protocol.Position{Line: 4, Character: 39},
+		},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, hoverS)
+
+	assert.Equal(t,
+		protocol.MarkupContent{
+			Kind:  protocol.Markdown,
+			Value: "**Type**\n\n```cadence\nFoo.S\n```\n\n**Documentation**\n\n docstring for S\n",
+		},
+		hoverS.Contents,
 	)
 }

--- a/languageserver/server/hover_test.go
+++ b/languageserver/server/hover_test.go
@@ -214,3 +214,88 @@ func TestHoverTypeImported(t *testing.T) {
 		hoverS.Contents,
 	)
 }
+
+func TestHoverMemberImported(t *testing.T) {
+	t.Parallel()
+
+	const fooCode = `
+      // docstring for Foo
+      access(all) contract Foo {
+
+          /// docstring for a
+          access(all) let a: Int
+
+          access(all) struct S {
+
+              /// docstring for foo
+              access(all) fun foo() {}
+          }
+
+          init() {
+              self.a = 1
+          }
+      }
+    `
+
+	const counterCode = `
+      import "Foo"
+
+      access(all) contract Counter {
+          access(all) fun run() {
+              let a = Foo.a
+              let s = Foo.S()
+              s.foo()
+          }
+      }
+    `
+
+	server, err := NewServer()
+	require.NoError(t, err)
+
+	err = server.SetOptions(
+		WithStringImportResolver(func(_ string, location common.StringLocation) (string, error) {
+			if location == "Foo" {
+				return fooCode, nil
+			}
+			return "", nil
+		}),
+	)
+	require.NoError(t, err)
+
+	server.projectIdentity = staticProjectIdentity("foobar")
+
+	counterURI := protocol.DocumentURI("file:///Foobar/cadence/contracts/Counter.cdc")
+	_, err = server.getDiagnostics(counterURI, counterCode, 1, func(*protocol.LogMessageParams) {})
+	require.NoError(t, err)
+
+	getHover := func(line, character uint32) *protocol.Hover {
+		t.Helper()
+
+		h, herr := server.Hover(
+			nil,
+			&protocol.TextDocumentPositionParams{
+				TextDocument: protocol.TextDocumentIdentifier{URI: counterURI},
+				Position:     protocol.Position{Line: line, Character: character},
+			},
+		)
+		require.NoError(t, herr)
+		require.NotNil(t, h)
+		return h
+	}
+
+	assert.Equal(t,
+		protocol.MarkupContent{
+			Kind:  protocol.Markdown,
+			Value: "**Type**\n\n```cadence\nInt\n```\n\n**Documentation**\n\n docstring for a\n",
+		},
+		getHover(5, 27).Contents,
+	)
+
+	assert.Equal(t,
+		protocol.MarkupContent{
+			Kind:  protocol.Markdown,
+			Value: "**Type**\n\n```cadence\nfun ()\n```\n\n**Documentation**\n\n docstring for foo\n",
+		},
+		getHover(7, 17).Contents,
+	)
+}

--- a/languageserver/server/location.go
+++ b/languageserver/server/location.go
@@ -69,3 +69,15 @@ func uriToLocation(uri protocol.DocumentURI) common.StringLocation {
 		strings.TrimPrefix(string(uri), filePrefix),
 	)
 }
+
+// locationToURI is the inverse of uriToLocation: it converts a file-backed
+// common.Location to a document URI. Returns an empty URI for non-file
+// locations (e.g. AddressLocation), which have no corresponding source file
+// the language server can resolve.
+func locationToURI(location common.Location) protocol.DocumentURI {
+	stringLocation, ok := location.(common.StringLocation)
+	if !ok {
+		return ""
+	}
+	return protocol.DocumentURI(filePrefix + string(stringLocation))
+}

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -2943,15 +2943,10 @@ func (s *Server) convertError(
 	case *sema.NotDeclaredMemberError:
 		var declarationGetter func(elaboration *sema.Elaboration) ast.Declaration
 
-		switch ty := err.Type.(type) {
-		case *sema.CompositeType:
+		switch err.Type.(type) {
+		case *sema.CompositeType, *sema.InterfaceType:
 			declarationGetter = func(elaboration *sema.Elaboration) ast.Declaration {
-				return elaboration.CompositeTypeDeclaration(ty)
-			}
-
-		case *sema.InterfaceType:
-			declarationGetter = func(elaboration *sema.Elaboration) ast.Declaration {
-				return elaboration.InterfaceTypeDeclaration(ty)
+				return elaboration.DeclarationForType(err.Type)
 			}
 		}
 

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -146,6 +146,13 @@ type AddressImportResolver func(projectID string, location common.AddressLocatio
 // AddressContractNamesResolver is a function that is used to resolve contract names of an address
 type AddressContractNamesResolver func(address common.Address) ([]string, error)
 
+// LocationToURIResolver maps an imported program's common.Location to
+// the document URI of its on-disk source. Used by go-to-definition to
+// jump across files when the imported file isn't currently open in the
+// editor. Returns an empty URI if the location can't be mapped (the
+// server falls back to scanning open documents in that case).
+type LocationToURIResolver func(projectID string, location common.Location) protocol.DocumentURI
+
 // StringImportResolver resolves string imports, scoped by project ID
 // projectID identifies the project configuration (e.g., flow.json path)
 type StringImportResolver func(projectID string, location common.StringLocation) (string, error)
@@ -185,6 +192,9 @@ type Server struct {
 	resolveStringImport StringImportResolver
 	// resolveIdentifierImport is the optional function that is used to resolve identifier imports (scoped by project)
 	resolveIdentifierImport func(projectID string, location common.IdentifierLocation) (string, error)
+	// resolveLocationToURI is the optional function that maps an imported
+	// program's location back to its on-disk URI for go-to-definition.
+	resolveLocationToURI LocationToURIResolver
 	// codeLensProviders are the functions that are used to provide code lenses for a checker
 	codeLensProviders []CodeLensProvider
 	// diagnosticProviders are the functions that are used to provide diagnostics for a checker
@@ -368,6 +378,20 @@ func WithStringImportResolver(resolver StringImportResolver) Option {
 func WithIdentifierImportResolver(resolver func(projectID string, location common.IdentifierLocation) (string, error)) Option {
 	return func(s *Server) error {
 		s.resolveIdentifierImport = resolver
+		return nil
+	}
+}
+
+// WithLocationToURIResolver returns a server option that sets the
+// function used by go-to-definition to map an imported program's
+// common.Location back to its on-disk document URI. Without it,
+// cross-file go-to-definition only works for locations whose on-disk
+// path the LSP can recover by itself (open documents, .cdc file
+// imports). flow.json-driven setups should provide one to make
+// identifier-style imports navigable.
+func WithLocationToURIResolver(resolver LocationToURIResolver) Option {
+	return func(s *Server) error {
+		s.resolveLocationToURI = resolver
 		return nil
 	}
 }
@@ -849,15 +873,27 @@ func (s *Server) Hover(
 		return nil, nil
 	}
 
+	origin := occurrence.Origin
+
 	var markup strings.Builder
 
 	_, _ = fmt.Fprintf(
 		&markup,
 		"**Type**\n\n```cadence\n%s\n```\n",
-		documentType(occurrence.Origin.Type),
+		documentType(origin.Type),
 	)
 
-	docString := occurrence.Origin.DocString
+	docString := origin.DocString
+	// If the docstring is empty and the type lives in a different file,
+	// fetch the declaration's docstring from that file's checker.
+	// This covers qualified references like `A.S` where `A` is imported:
+	// the nested type's declaration is not in the current elaboration.
+	if docString == "" {
+		_, decl, _ := s.foreignDeclaration(uri, origin.Type)
+		if decl != nil {
+			docString = decl.DeclarationDocString()
+		}
+	}
 	if docString != "" {
 		_, _ = fmt.Fprintf(
 			&markup,
@@ -938,7 +974,40 @@ func (s *Server) Definition(
 	}
 
 	origin := occurrence.Origin
-	if origin == nil || origin.StartPos == nil || origin.EndPos == nil {
+	if origin == nil {
+		return nil, nil
+	}
+
+	// If the origin's type is located in a different file,
+	// attempt to resolve the declaration in that file's checker.
+	// This handles cross-file go-to-definition for both top-level imported types
+	// (e.g. `A` where A is imported) and qualified nested type references (e.g. `S` in `A.S`).
+	//
+	// When the type lives elsewhere, the origin's same-file StartPos/EndPos are not trustworthy:
+	// for imported variables the checker records ast.EmptyPosition (0:0),
+	// which would otherwise point go-to-def at the top of the current document.
+	//
+	// Return nil if the cross-file lookup can't produce a URI rather than the misleading same-file range.
+	if foreignURI, decl, crossFile := s.foreignDeclaration(uri, origin.Type); crossFile {
+		if decl == nil || foreignURI == "" {
+			return nil, nil
+		}
+
+		declIdentifier := decl.DeclarationIdentifier()
+		if declIdentifier == nil {
+			return nil, nil
+		}
+
+		return &protocol.Location{
+			URI: foreignURI,
+			Range: conversion.ASTToProtocolRange(
+				declIdentifier.StartPosition(),
+				declIdentifier.EndPosition(nil),
+			),
+		}, nil
+	}
+
+	if origin.StartPos == nil || origin.EndPos == nil {
 		return nil, nil
 	}
 
@@ -949,6 +1018,90 @@ func (s *Server) Definition(
 			*origin.EndPos,
 		),
 	}, nil
+}
+
+// foreignDeclaration returns the URI and declaration AST node for the given type,
+// if it is declared in a different file than uri.
+// crossFile reports whether the type lives in another file at all
+// (regardless of whether the declaration was actually resolvable) —
+// callers can use this to distinguish "look up failed, give up"
+// from "the type is local, fall through to local handling".
+func (s *Server) foreignDeclaration(
+	uri protocol.DocumentURI,
+	ty sema.Type,
+) (foreignURI protocol.DocumentURI, decl ast.Declaration, crossFile bool) {
+	locatedType, ok := ty.(sema.LocatedType)
+	if !ok {
+		return "", nil, false
+	}
+
+	typeLocation := locatedType.GetLocation()
+	if typeLocation == nil || typeLocation == uriToLocation(uri) {
+		return "", nil, false
+	}
+
+	foreignURI, decl = s.resolveCrossFileDeclaration(uri, typeLocation, ty)
+	return foreignURI, decl, true
+}
+
+// resolveCrossFileDeclaration looks up the declaration AST node for the given type residing in another file.
+// Returns a URI for the foreign file when one is known, an empty URI otherwise
+// (e.g. for identifier-style imports like  `import "Foo"` where the on-disk path isn't directly derivable).
+func (s *Server) resolveCrossFileDeclaration(
+	parentURI protocol.DocumentURI,
+	typeLocation common.Location,
+	ty sema.Type,
+) (protocol.DocumentURI, ast.Declaration) {
+	projectID := s.projectIdentity.ProjectIDForURI(parentURI)
+
+	foreignChecker := s.checkerForLocation(projectID, typeLocation)
+	if foreignChecker == nil {
+		return "", nil
+	}
+
+	decl := foreignChecker.Elaboration.DeclarationForType(ty)
+	if decl == nil {
+		return "", nil
+	}
+
+	return s.uriForLocation(parentURI, typeLocation), decl
+}
+
+// checkerForLocation looks up a cached checker by location for the given project ID.
+func (s *Server) checkerForLocation(projectID string, location common.Location) *sema.Checker {
+	checker, ok := s.checkerCache.Get(CheckerKey{ProjectID: projectID, Location: location})
+	if !ok {
+		return nil
+	}
+
+	return checker
+}
+
+// uriForLocation maps a common.Location to a document URI.
+// Order:
+// (1) a user-supplied LocationToURIResolver
+// (2) the inverse of uriToLocation for path-style locations //
+// (3) a scan of currently-open documents
+
+// Returns "" if no mapping is found.
+func (s *Server) uriForLocation(parentURI protocol.DocumentURI, location common.Location) protocol.DocumentURI {
+	if s.resolveLocationToURI != nil {
+		projectID := s.projectIdentity.ProjectIDForURI(parentURI)
+		if uri := s.resolveLocationToURI(projectID, location); uri != "" {
+			return uri
+		}
+	}
+
+	if isPathLocation(location) {
+		return locationToURI(location)
+	}
+
+	for uri := range s.documents {
+		if uriToLocation(uri) == location {
+			return uri
+		}
+	}
+	return ""
 }
 
 func (s *Server) SignatureHelp(
@@ -2737,11 +2890,7 @@ func (s *Server) convertError(
 		switch ty := err.Type.(type) {
 		case *sema.CompositeType:
 			declarationGetter = func(elaboration *sema.Elaboration) ast.Declaration {
-				decl, ok := elaboration.CompositeTypeDeclaration(ty)
-				if !ok {
-					return nil
-				}
-				return decl
+				return elaboration.CompositeTypeDeclaration(ty)
 			}
 
 		case *sema.InterfaceType:

--- a/languageserver/server/server.go
+++ b/languageserver/server/server.go
@@ -889,7 +889,7 @@ func (s *Server) Hover(
 	// This covers qualified references like `A.S` where `A` is imported:
 	// the nested type's declaration is not in the current elaboration.
 	if docString == "" {
-		_, decl, _ := s.foreignDeclaration(uri, origin.Type)
+		_, decl, _ := s.foreignDeclaration(uri, origin)
 		if decl != nil {
 			docString = decl.DeclarationDocString()
 		}
@@ -988,7 +988,7 @@ func (s *Server) Definition(
 	// which would otherwise point go-to-def at the top of the current document.
 	//
 	// Return nil if the cross-file lookup can't produce a URI rather than the misleading same-file range.
-	if foreignURI, decl, crossFile := s.foreignDeclaration(uri, origin.Type); crossFile {
+	if foreignURI, decl, crossFile := s.foreignDeclaration(uri, origin); crossFile {
 		if decl == nil || foreignURI == "" {
 			return nil, nil
 		}
@@ -1011,27 +1011,67 @@ func (s *Server) Definition(
 		return nil, nil
 	}
 
+	protocolRange := conversion.ASTToProtocolRange(
+		*origin.StartPos,
+		*origin.EndPos,
+	)
+
+	// Member access might be on a value whose type lives in another file
+	if memberAccess := checker.PositionInfo.MemberAccesses.Find(position); memberAccess != nil {
+		if foreignURI := s.foreignURIForType(uri, memberAccess.AccessedType); foreignURI != "" {
+			return &protocol.Location{
+				URI:   foreignURI,
+				Range: protocolRange,
+			}, nil
+		}
+	}
+
 	return &protocol.Location{
-		URI: uri,
-		Range: conversion.ASTToProtocolRange(
-			*origin.StartPos,
-			*origin.EndPos,
-		),
+		URI:   uri,
+		Range: protocolRange,
 	}, nil
 }
 
-// foreignDeclaration returns the URI and declaration AST node for the given type,
-// if it is declared in a different file than uri.
-// crossFile reports whether the type lives in another file at all
-// (regardless of whether the declaration was actually resolvable) —
-// callers can use this to distinguish "look up failed, give up"
-// from "the type is local, fall through to local handling".
+// foreignURIForType returns the document URI for the given type's
+// source file when that file is different from parentURI.
+// Returns "" when the type isn't file-located or lives in parentURI's file.
+// Reference and optional wrappers are stripped so member access on `&T`
+// resolves through to T's location.
+func (s *Server) foreignURIForType(parentURI protocol.DocumentURI, ty sema.Type) protocol.DocumentURI {
+	locatedType := unwrapToLocatedType(ty)
+	if locatedType == nil {
+		return ""
+	}
+
+	typeLocation := locatedType.GetLocation()
+	if typeLocation == nil || typeLocation == uriToLocation(parentURI) {
+		return ""
+	}
+
+	return s.uriForLocation(parentURI, typeLocation)
+}
+
+// foreignDeclaration returns the URI and declaration AST node for the given
+// origin's type, if it is a type-declaration reference (struct, contract, interface, ...)
+// declared in a different file than uri.
+//
+// crossFile reports whether the origin should be treated as a cross-file type reference.
+// Callers use it to distinguish "the lookup applies but failed"
+// from "the origin isn't a cross-file type reference at all".
 func (s *Server) foreignDeclaration(
 	uri protocol.DocumentURI,
-	ty sema.Type,
-) (foreignURI protocol.DocumentURI, decl ast.Declaration, crossFile bool) {
-	locatedType, ok := ty.(sema.LocatedType)
-	if !ok {
+	origin *sema.Origin,
+) (
+	foreignURI protocol.DocumentURI,
+	decl ast.Declaration,
+	crossFile bool,
+) {
+	if origin == nil || !origin.DeclarationKind.IsTypeDeclaration() {
+		return "", nil, false
+	}
+
+	locatedType := unwrapToLocatedType(origin.Type)
+	if locatedType == nil {
 		return "", nil, false
 	}
 
@@ -1040,8 +1080,24 @@ func (s *Server) foreignDeclaration(
 		return "", nil, false
 	}
 
-	foreignURI, decl = s.resolveCrossFileDeclaration(uri, typeLocation, ty)
+	foreignURI, decl = s.resolveCrossFileDeclaration(uri, typeLocation, locatedType)
 	return foreignURI, decl, true
+}
+
+// unwrapToLocatedType strips potential reference and optional wrappers
+func unwrapToLocatedType(ty sema.Type) sema.LocatedType {
+	for {
+		switch t := ty.(type) {
+		case *sema.ReferenceType:
+			ty = t.Type
+		case *sema.OptionalType:
+			ty = t.Type
+		case sema.LocatedType:
+			return t
+		default:
+			return nil
+		}
+	}
 }
 
 // resolveCrossFileDeclaration looks up the declaration AST node for the given type residing in another file.


### PR DESCRIPTION
⚠️ Depends on https://github.com/onflow/cadence/pull/4487


## Description

Add support for hover and go-to-definition on imported types, including nested types, and imported members.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/cadence-lint/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
